### PR TITLE
Fixed annotation state after adding files to session

### DIFF
--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -87,6 +87,7 @@ def add_files_to_session(
         if u"{session_id}" in session["title"]:
             session["title"] = session["title"].replace(u"{session_id}", str(session_id))
     session["last_update"] = datetime.now()
+    annot._p_changed = True
     return session_id, session
 
 


### PR DESCRIPTION
Le problème était que le _p_mtime de l'annotation des sessions ne se met pas à jour. Donc le cache de FilesBelongingToAGivenSession non plus