### PR TITLE
Updated SigningUsersCsv view to send emails to signers

### DIFF
--- a/src/imio/esign/browser/settings.py
+++ b/src/imio/esign/browser/settings.py
@@ -4,8 +4,8 @@ from imio.esign import _
 from plone import api
 from plone.app.registry.browser.controlpanel import ControlPanelFormWrapper
 from plone.app.registry.browser.controlpanel import RegistryEditForm
-from plone.registry.interfaces import IRecordModifiedEvent
 from plone.z3cform import layout
+from string import Formatter
 from zope import schema
 from zope.interface import Interface
 from zope.interface import Invalid
@@ -38,6 +38,15 @@ def validate_vat_number(va_nb):
 
     return True
 
+def validate_signing_users_email_content(value):
+    """Allow only known placeholders in the email template."""
+    allowed = {"fullname", "firstname", "lastname", "email", "userid"}
+    for _ignored1, field, _ignored2, _ignored3 in Formatter().parse(value or ""):
+        if field and field not in allowed:
+            raise Invalid(
+                _("Unknown placeholder: ${field}", mapping={"field": field})
+            )
+    return True
 
 class IImioEsignSettings(Interface):
 
@@ -85,6 +94,7 @@ class IImioEsignSettings(Interface):
             "Use {fullname}, {firstname}, {lastname}, {email}, {userid} as placeholders."
         ),
         required=False,
+        constraint=validate_signing_users_email_content,
         default=u"""Hello {fullname},
 
 You have been invited to Parapheo, the signing platform of iMio.

--- a/src/imio/esign/browser/settings.py
+++ b/src/imio/esign/browser/settings.py
@@ -92,10 +92,12 @@ class IImioEsignSettings(Interface):
             "TAL compliant with variables: view, context, user_data, parapheo_url, request and modules."
         ),
         required=False,
+    )
 
     max_session_size = schema.Int(
         title=_("Max session size (MB)"),
-        description=_("Maximum size of the session in megabytes. If the total size of files to be signed exceeds this limit, a new session will be created."),
+        description=_("Maximum size of the session in megabytes. If the total size of files to be signed exceeds this "
+                      "limit, a new session will be created."),
         default=100,
         min=1,
         required=True,

--- a/src/imio/esign/browser/settings.py
+++ b/src/imio/esign/browser/settings.py
@@ -78,6 +78,32 @@ class IImioEsignSettings(Interface):
         required=False,
     )
 
+    signing_users_email_content = schema.Text(
+        title=_("Email content for signing users"),
+        description=_(
+            "Email content sent to users when inviting them to Parapheo. "
+            "Use {fullname}, {firstname}, {lastname}, {email}, {userid} as placeholders."
+        ),
+        required=False,
+        # TODO Replace Luxtrust URL with production URL
+        default=u"""Hello {fullname},
+
+You have been invited to Parapheo, the signing platform of iMio.
+
+Before you can sign documents, you need to activate your account.
+
+Please follow these steps:
+1. Go to https://simplycosi-1-test.trustsigneurope.com/login?tenantName=IMIO
+2. Use your email address ({email}) as username
+3. Click on 'Forgot password' to set your password
+4. Make sure you can log in successfully
+
+You only need to do this once. After that, you'll be able to sign documents.
+
+Best regards,
+The iMio Team""",
+    )
+
 
 class ImioEsignSettings(RegistryEditForm):
     schema = IImioEsignSettings

--- a/src/imio/esign/browser/settings.py
+++ b/src/imio/esign/browser/settings.py
@@ -38,6 +38,7 @@ def validate_vat_number(va_nb):
 
     return True
 
+
 def validate_signing_users_email_content(value):
     """Allow only known placeholders in the email template."""
     allowed = {"fullname", "firstname", "lastname", "email", "userid"}
@@ -47,6 +48,7 @@ def validate_signing_users_email_content(value):
                 _("Unknown placeholder: ${field}", mapping={"field": field})
             )
     return True
+
 
 class IImioEsignSettings(Interface):
 
@@ -95,22 +97,6 @@ class IImioEsignSettings(Interface):
         ),
         required=False,
         constraint=validate_signing_users_email_content,
-        default=u"""Hello {fullname},
-
-You have been invited to Parapheo, the signing platform of iMio.
-
-Before you can sign documents, you need to activate your account.
-
-Please follow these steps:
-1. Go to https://simplycosi-1.trustsigneurope.com/login?tenantName=IMIO
-2. Use your email address ({email}) as username
-3. Click on 'Forgot password' to set your password
-4. Make sure you can log in successfully
-
-You only need to do this once. After that, you'll be able to sign documents.
-
-Best regards,
-The iMio Team""",
     )
 
 

--- a/src/imio/esign/browser/settings.py
+++ b/src/imio/esign/browser/settings.py
@@ -85,7 +85,6 @@ class IImioEsignSettings(Interface):
             "Use {fullname}, {firstname}, {lastname}, {email}, {userid} as placeholders."
         ),
         required=False,
-        # TODO Replace Luxtrust URL with production URL
         default=u"""Hello {fullname},
 
 You have been invited to Parapheo, the signing platform of iMio.
@@ -93,7 +92,7 @@ You have been invited to Parapheo, the signing platform of iMio.
 Before you can sign documents, you need to activate your account.
 
 Please follow these steps:
-1. Go to https://simplycosi-1-test.trustsigneurope.com/login?tenantName=IMIO
+1. Go to https://simplycosi-1.trustsigneurope.com/login?tenantName=IMIO
 2. Use your email address ({email}) as username
 3. Click on 'Forgot password' to set your password
 4. Make sure you can log in successfully

--- a/src/imio/esign/browser/settings.py
+++ b/src/imio/esign/browser/settings.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from imio.esign import _
-from plone import api
 from plone.app.registry.browser.controlpanel import ControlPanelFormWrapper
 from plone.app.registry.browser.controlpanel import RegistryEditForm
+from plone.app.z3cform.wysiwyg import WysiwygFieldWidget
+from plone.autoform.directives import widget
 from plone.z3cform import layout
-from string import Formatter
 from zope import schema
 from zope.interface import Interface
 from zope.interface import Invalid
@@ -36,17 +36,6 @@ def validate_vat_number(va_nb):
     if control != expected_control:
         raise Invalid(_("Invalid VAT number: checksum verification failed"))
 
-    return True
-
-
-def validate_signing_users_email_content(value):
-    """Allow only known placeholders in the email template."""
-    allowed = {"fullname", "firstname", "lastname", "email", "userid"}
-    for _ignored1, field, _ignored2, _ignored3 in Formatter().parse(value or ""):
-        if field and field not in allowed:
-            raise Invalid(
-                _("Unknown placeholder: ${field}", mapping={"field": field})
-            )
     return True
 
 
@@ -89,14 +78,20 @@ class IImioEsignSettings(Interface):
         required=False,
     )
 
+    parapheo_url = schema.TextLine(
+        title=_("Parapheo url"),
+        description=_("Used in signers email template."),
+        required=False,
+    )
+
+    widget("signing_users_email_content", WysiwygFieldWidget)
     signing_users_email_content = schema.Text(
-        title=_("Email content for signing users"),
+        title=_("Email content model for signing users"),
         description=_(
             "Email content sent to users when inviting them to Parapheo. "
-            "Use {fullname}, {firstname}, {lastname}, {email}, {userid} as placeholders."
+            "TAL compliant with variables: view, context, user_data, parapheo_url, request and modules."
         ),
         required=False,
-        constraint=validate_signing_users_email_content,
     )
 
 

--- a/src/imio/esign/browser/templates/signing_users.pt
+++ b/src/imio/esign/browser/templates/signing_users.pt
@@ -177,7 +177,7 @@
                             Deselect All
                         </button>
                         <span class="stats">
-                            <strong i18n:translate="">Selected:</strong> 
+                            <strong i18n:translate="">Selected:</strong>
                 <span id="selected-count">0</span>
                             / <span tal:content="python:len(all_users)">0</span>
                         </span>
@@ -195,7 +195,12 @@
                     </div>
                 </div>
 
-                <form id="users-form" method="post">
+                <form id="users-form" method="post" tal:attributes="action string:${context/absolute_url}/@@signing-users-csv">
+                    <!-- Hidden inputs for form submission -->
+                    <input type="hidden" name="_authenticator" tal:attributes="value context/@@authenticator/token" />
+                    <input type="hidden" name="action" id="form-action" value="" />
+                    <input type="hidden" name="selected_users" id="selected-users" value="" />
+
                     <table class="listing" id="users-table" style="width: 100%;">
                         <thead>
                             <tr>
@@ -217,7 +222,7 @@
                                         style python:'background-color: #ffe6e6' if user.get('has_duplicate_email') else ''">
                                     <td>
                                         <input type="checkbox"
-                                            name="selected_users"
+                                            name="user_checkbox"
                                             class="user-checkbox"
                                             tal:attributes="value user/userid;
                                                    checked python:'checked' if user['checked'] else None" />
@@ -286,7 +291,7 @@
         function updateSelectedCount() {
             var count = document.querySelectorAll('.user-checkbox:checked').length;
             selectedCount.textContent = count;
-            
+
             // Update select all checkbox state
             var allChecked = Array.from(checkboxes).every(function(cb) { return cb.checked; });
             var someChecked = Array.from(checkboxes).some(function(cb) { return cb.checked; });
@@ -311,11 +316,11 @@
                 return;
             }
 
-            var url = window.location.href.split('?')[0];
-            var params = 'action=' + action + '&selected_users=' + encodeURIComponent(JSON.stringify(selected));
-            
             if (action === 'download_csv') {
-                window.location.href = url + '?' + params;
+                // For CSV download, set the action and selected users, then submit
+                document.getElementById('form-action').value = action;
+                document.getElementById('selected-users').value = JSON.stringify(selected);
+                form.submit();
             } else if (action === 'send_emails') {
                 // Show confirmation modal
                 document.getElementById('email-count').textContent = selected.length;
@@ -376,9 +381,11 @@
 
         confirmEmailBtn.addEventListener('click', function() {
             var selected = getSelectedUserIds();
-            var url = window.location.href.split('?')[0];
-            var params = 'action=send_emails&selected_users=' + encodeURIComponent(JSON.stringify(selected));
-            window.location.href = url + '?' + params;
+            // Set the action and selected users in hidden inputs
+            document.getElementById('form-action').value = 'send_emails';
+            document.getElementById('selected-users').value = JSON.stringify(selected);
+            // Submit the form via POST
+            form.submit();
         });
 
         // Close modal on outside click

--- a/src/imio/esign/browser/templates/signing_users.pt
+++ b/src/imio/esign/browser/templates/signing_users.pt
@@ -1,0 +1,399 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:metal="http://xml.zope.org/namespaces/metal"
+    xmlns:tal="http://xml.zope.org/namespaces/tal"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    metal:use-macro="context/main_template/macros/master"
+    i18n:domain="imio.esign">
+
+    <metal:block fill-slot="content-core">
+        <style>
+            #content-core {
+            max-width: 100%;
+            }
+            .signing-users-container h1 {
+            margin-top: 0;
+            color: #333;
+            border-bottom: 2px solid #007bff;
+            padding-bottom: 10px;
+            }
+            .action-bar {
+            margin: 20px 0;
+            padding: 20px;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            }
+            .action-bar > div {
+            margin-bottom: 15px;
+            }
+            .action-bar > div:last-child {
+            margin-bottom: 0;
+            }
+            .btn {
+            display: inline-block;
+            padding: 10px 20px;
+            margin: 0 5px 5px 0;
+            border: 1px solid transparent;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 14px;
+            text-decoration: none;
+            transition: all 0.2s;
+            }
+            .btn:hover {
+            opacity: 0.9;
+            transform: translateY(-1px);
+            box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+            }
+            .btn-primary {
+            background-color: #007bff;
+            color: white;
+            border-color: #007bff;
+            }
+            .btn-secondary {
+            background-color: #6c757d;
+            color: white;
+            border-color: #6c757d;
+            }
+            .btn-success {
+            background-color: #28a745;
+            color: white;
+            border-color: #28a745;
+            }
+            .btn-info {
+            background-color: #17a2b8;
+            color: white;
+            border-color: #17a2b8;
+            }
+            .btn-danger {
+            background-color: #dc3545;
+            color: white;
+            border-color: #dc3545;
+            }
+            .stats {
+            display: inline-block;
+            margin-left: 20px;
+            padding: 8px 15px;
+            background-color: white;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            }
+            table.listing {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 20px 0;
+            background-color: white;
+            }
+            table.listing th,
+            table.listing td {
+            padding: 12px 8px;
+            border: 1px solid #dee2e6;
+            text-align: left;
+            }
+            table.listing th {
+            background-color: #e9ecef;
+            font-weight: bold;
+            position: sticky;
+            top: 0;
+            z-index: 10;
+            }
+            table.listing tbody tr:hover {
+            background-color: #f8f9fa;
+            }
+            table.listing tbody tr.checked-by-default {
+            font-weight: normal;
+            }
+            #email-confirmation-modal {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0,0,0,0.6);
+            z-index: 10000;
+            }
+            .modal-content {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background: white;
+            padding: 30px;
+            border-radius: 8px;
+            max-width: 600px;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+            }
+            .modal-content h2 {
+            margin-top: 0;
+            color: #333;
+            }
+            .modal-content .portalMessage {
+            margin: 15px 0;
+            }
+            .modal-actions {
+            margin-top: 25px;
+            text-align: right;
+            }
+        </style>
+
+        <div class="signing-users-container">
+            <tal:block
+                define="users_data python:view.get_users_data();
+                       all_users python:users_data[0];
+                       duplicates python:users_data[1];">
+
+                <h1 i18n:translate="">Signing Users: Export CSV</h1>
+
+                <!-- Duplicate email warnings -->
+                <tal:duplicates condition="duplicates">
+                    <div class="portalMessage error">
+                        <strong i18n:translate="">Warning: Duplicate email addresses detected</strong>
+                        <ul>
+                            <tal:block repeat="item python:sorted(duplicates.items())">
+                                <li>
+                                    <strong i18n:translate="">Email:</strong> <span
+                                        tal:content="python:item[0]">email@example.com</span> - <strong
+                                        i18n:translate="">Users:</strong> <span
+                                        tal:content="python:', '.join(item[1])">user1, user2</span>
+                                </li>
+                            </tal:block>
+                        </ul>
+                    </div>
+                </tal:duplicates>
+
+                <div class="action-bar">
+                    <div>
+                        <button type="button" id="select-all-btn" class="btn btn-secondary"
+                            i18n:translate="">
+                            Select All
+                        </button>
+                        <button type="button" id="select-signing-users-btn" class="btn btn-info"
+                            i18n:translate="">
+                            Select Only Signers
+                        </button>
+                        <button type="button" id="deselect-all-btn" class="btn btn-secondary"
+                            i18n:translate="">
+                            Deselect All
+                        </button>
+                        <span class="stats">
+                            <strong i18n:translate="">Selected:</strong> 
+                <span id="selected-count">0</span>
+                            / <span tal:content="python:len(all_users)">0</span>
+                        </span>
+                    </div>
+
+                    <div>
+                        <button type="button" id="download-csv-btn" class="btn btn-primary"
+                            i18n:translate="">
+                            📥 Download CSV
+                        </button>
+                        <button type="button" id="send-email-btn" class="btn btn-success"
+                            i18n:translate="">
+                            ✉️ Send Emails
+                        </button>
+                    </div>
+                </div>
+
+                <form id="users-form" method="post">
+                    <table class="listing" id="users-table" style="width: 100%;">
+                        <thead>
+                            <tr>
+                                <th style="width: 40px;">
+                                    <input type="checkbox" id="select-all-checkbox" />
+                                </th>
+                                <th i18n:translate="">User ID</th>
+                                <th i18n:translate="">Email</th>
+                                <th i18n:translate="">Last Name</th>
+                                <th i18n:translate="">First Name</th>
+                                <th i18n:translate="">Full Name</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tal:block repeat="user all_users">
+                                <tr
+                                    tal:attributes="class python:'checked-by-default' if user['checked'] else '';
+                                        data-userid user/userid;
+                                        style python:'background-color: #ffe6e6' if user.get('has_duplicate_email') else ''">
+                                    <td>
+                                        <input type="checkbox"
+                                            name="selected_users"
+                                            class="user-checkbox"
+                                            tal:attributes="value user/userid;
+                                                   checked python:'checked' if user['checked'] else None" />
+                                    </td>
+                                    <td tal:content="user/userid">userid</td>
+                                    <td tal:content="user/email">email@example.com</td>
+                                    <td tal:content="user/lastname">Lastname</td>
+                                    <td tal:content="user/firstname">Firstname</td>
+                                    <td tal:content="user/fullname">Full Name</td>
+                                </tr>
+                            </tal:block>
+                        </tbody>
+                    </table>
+                </form>
+
+                <!-- Email confirmation modal -->
+                <div id="email-confirmation-modal">
+                    <div class="modal-content">
+                        <h2 i18n:translate="">Confirm Email Sending</h2>
+                        <div class="portalMessage error">
+                            <strong i18n:translate="">Important:</strong>
+                            <p i18n:translate="">
+                                Before sending emails, please ensure that all selected users have
+                                their accounts
+                                created in "Wallonie Connect" (WaCo). If not, send the CSV to the
+                                DevOps team
+                                and wait for account creation.
+                            </p>
+                        </div>
+                        <p>
+                            <span i18n:translate="">You are about to send emails to</span>
+                            <strong>
+                                <span id="email-count">0</span>
+                            </strong>
+                            <span i18n:translate="">users.</span>
+                        </p>
+                        <div class="modal-actions">
+                            <button type="button" id="cancel-email-btn" class="btn btn-secondary"
+                                i18n:translate="">
+                                Cancel
+                            </button>
+                            <button type="button" id="confirm-email-btn" class="btn btn-danger"
+                                i18n:translate="">
+                                Send Emails
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <script type="text/javascript">
+                    //<![CDATA[
+    (function() {
+        var form = document.getElementById('users-form');
+        var checkboxes = document.querySelectorAll('.user-checkbox');
+        var selectAllCheckbox = document.getElementById('select-all-checkbox');
+        var selectAllBtn = document.getElementById('select-all-btn');
+        var selectSigningUsersBtn = document.getElementById('select-signing-users-btn');
+        var deselectAllBtn = document.getElementById('deselect-all-btn');
+        var downloadBtn = document.getElementById('download-csv-btn');
+        var sendEmailBtn = document.getElementById('send-email-btn');
+        var modal = document.getElementById('email-confirmation-modal');
+        var cancelEmailBtn = document.getElementById('cancel-email-btn');
+        var confirmEmailBtn = document.getElementById('confirm-email-btn');
+        var selectedCount = document.getElementById('selected-count');
+
+        function updateSelectedCount() {
+            var count = document.querySelectorAll('.user-checkbox:checked').length;
+            selectedCount.textContent = count;
+            
+            // Update select all checkbox state
+            var allChecked = Array.from(checkboxes).every(function(cb) { return cb.checked; });
+            var someChecked = Array.from(checkboxes).some(function(cb) { return cb.checked; });
+            selectAllCheckbox.checked = allChecked;
+            selectAllCheckbox.indeterminate = someChecked && !allChecked;
+        }
+
+        function getSelectedUserIds() {
+            var selected = [];
+            checkboxes.forEach(function(checkbox) {
+                if (checkbox.checked) {
+                    selected.push(checkbox.value);
+                }
+            });
+            return selected;
+        }
+
+        function performAction(action) {
+            var selected = getSelectedUserIds();
+            if (selected.length === 0) {
+                alert('Please select at least one user.');
+                return;
+            }
+
+            var url = window.location.href.split('?')[0];
+            var params = 'action=' + action + '&selected_users=' + encodeURIComponent(JSON.stringify(selected));
+            
+            if (action === 'download_csv') {
+                window.location.href = url + '?' + params;
+            } else if (action === 'send_emails') {
+                // Show confirmation modal
+                document.getElementById('email-count').textContent = selected.length;
+                modal.style.display = 'block';
+            }
+        }
+
+        // Event listeners
+        checkboxes.forEach(function(checkbox) {
+            checkbox.addEventListener('change', updateSelectedCount);
+        });
+
+        selectAllCheckbox.addEventListener('change', function() {
+            checkboxes.forEach(function(checkbox) {
+                checkbox.checked = selectAllCheckbox.checked;
+            });
+            updateSelectedCount();
+        });
+
+        selectAllBtn.addEventListener('click', function() {
+            checkboxes.forEach(function(checkbox) {
+                checkbox.checked = true;
+            });
+            updateSelectedCount();
+        });
+
+        selectSigningUsersBtn.addEventListener('click', function() {
+            checkboxes.forEach(function(checkbox) {
+                var row = checkbox.closest('tr');
+                // Check if this row has the 'checked-by-default' class
+                if (row && row.classList.contains('checked-by-default')) {
+                    checkbox.checked = true;
+                } else {
+                    checkbox.checked = false;
+                }
+            });
+            updateSelectedCount();
+        });
+
+        deselectAllBtn.addEventListener('click', function() {
+            checkboxes.forEach(function(checkbox) {
+                checkbox.checked = false;
+            });
+            updateSelectedCount();
+        });
+
+        downloadBtn.addEventListener('click', function() {
+            performAction('download_csv');
+        });
+
+        sendEmailBtn.addEventListener('click', function() {
+            performAction('send_emails');
+        });
+
+        cancelEmailBtn.addEventListener('click', function() {
+            modal.style.display = 'none';
+        });
+
+        confirmEmailBtn.addEventListener('click', function() {
+            var selected = getSelectedUserIds();
+            var url = window.location.href.split('?')[0];
+            var params = 'action=send_emails&selected_users=' + encodeURIComponent(JSON.stringify(selected));
+            window.location.href = url + '?' + params;
+        });
+
+        // Close modal on outside click
+        modal.addEventListener('click', function(e) {
+            if (e.target === modal) {
+                modal.style.display = 'none';
+            }
+        });
+
+        // Initial count update
+        updateSelectedCount();
+    })();
+    //]]>
+                </script>
+            </tal:block>
+        </div>
+    </metal:block>
+</html>

--- a/src/imio/esign/browser/templates/signing_users.pt
+++ b/src/imio/esign/browser/templates/signing_users.pt
@@ -5,7 +5,7 @@
     metal:use-macro="context/main_template/macros/master"
     i18n:domain="imio.esign">
 
-    <metal:block fill-slot="content-core">
+    <metal:block fill-slot="content">
         <style>
             #content-core {
             max-width: 100%;
@@ -136,6 +136,10 @@
             text-align: right;
             }
         </style>
+
+        <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+            Status message
+        </div>
 
         <div class="signing-users-container">
             <tal:block

--- a/src/imio/esign/browser/views.py
+++ b/src/imio/esign/browser/views.py
@@ -8,10 +8,14 @@ from imio.esign import manage_session_perm
 from imio.esign.browser.table import external_session_link
 from imio.esign.browser.table import SessionsTable
 from imio.esign.config import get_registry_enabled
+from imio.esign.config import get_registry_signing_users_email_content
 from imio.esign.utils import create_external_session
 from imio.esign.utils import get_session_annotation
 from imio.esign.utils import remove_session
 from imio.helpers.content import uuidToObject
+from imio.helpers.emailer import create_html_email
+from imio.helpers.emailer import get_mail_host
+from imio.helpers.emailer import send_email
 from imio.helpers.security import separate_fullname
 from imio.prettylink.interfaces import IPrettyLink
 from imio.pyutils.utils import safe_encode
@@ -27,6 +31,7 @@ from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
 
 import csv
+import json
 import os
 
 
@@ -364,53 +369,61 @@ class DownloadFileView(BrowserView):
         </body>
         </html>
         """.format(
-            title=page_title,
-            heading=heading,
-            message=message
+            title=page_title, heading=heading, message=message
         )
 
         return html
 
 
 class SigningUsersCsv(BrowserView):
-    """Get users, checking for duplicate emails, and output a CSV.
+    """Get users, checking for duplicate emails, output a CSV, and send emails.
     This view can be subclassed to redefine custom filtering logic.
     """
 
+    index = ViewPageTemplateFile("templates/signing_users.pt")
+
     def __call__(self):
-        fn_first = True
-        if self.request.get("fn_first", "1") == "0":
-            fn_first = False
-        apply_filter = self.request.get("apply_filter", "1") == "1"
-        if self.request.get("download", "") == "1":
-            return self._generate_csv(fn_first, apply_filter)
-        return self._generate_html(fn_first, apply_filter=apply_filter)
+        # Handle CSV download
+        if self.request.get("action") == "download_csv":
+            return self._download_csv()
+
+        # Handle email sending
+        if self.request.get("action") == "send_emails":
+            return self._send_emails()
+
+        # Default: display the table
+        return self.index()
 
     def filter_user(self, user_data):
-        """Filter method to determine if a user should be included in CSV output.
+        """Filter method to determine if a user should be included by default.
 
         :param user_data: dict containing user data (userid, email, lastname, firstname, fullname)
-        :return: True to include the user in CSV, False to exclude
+        :return: True to include the user by default, False to exclude
         """
         return True
 
-    def _collect_users_data(self, fn_first):
-        """Get users and duplicates.
+    def get_users_data(self):
+        """Get all users data sorted by filter status then userid.
 
-        :param fn_first: Boolean indicating if firstname comes first
-        :return: (all_users_data, filtered_users_data, duplicates)
+        :return: list of user data dictionaries with 'checked' status
         """
+        fn_first = True
         portal = api.portal.get()
         catalog = getToolByName(portal, "portal_catalog")
         acl_users = getToolByName(portal, "acl_users")
 
-        all_users_data = {}
+        all_users_data = []
         email_registry = {}
 
         for user_info in acl_users.searchUsers():
             userid = user_info.get("userid")
-            if not userid or userid in all_users_data:
+            if not userid:
                 continue
+
+            # Skip duplicates
+            if any(u["userid"] == userid for u in all_users_data):
+                continue
+
             user_obj = api.user.get(userid=userid)
             if not user_obj:
                 continue
@@ -419,11 +432,8 @@ class SigningUsersCsv(BrowserView):
             fullname = user_obj.getProperty("fullname", "")
             lastname = firstname = ""
 
-            # Do we have a person with this userid ?
-            brains = catalog.searchResults(
-                portal_type="person",
-                userid=userid
-            )
+            # Do we have a person with this userid?
+            brains = catalog.searchResults(portal_type="person", userid=userid)
             if brains:
                 person = brains[0].getObject()
                 lastname = getattr(person, "lastname", "") or ""
@@ -444,125 +454,160 @@ class SigningUsersCsv(BrowserView):
                 "firstname": firstname,
                 "fullname": fullname,
             }
-            all_users_data[userid] = user_data
+
+            # Determine if user should be checked by default
+            user_data["checked"] = self.filter_user(user_data)
+
+            all_users_data.append(user_data)
 
             if email:
                 email_registry.setdefault(email, []).append(userid)
 
+        # Calculate duplicates
         duplicates = {email: userids for email, userids in email_registry.items() if len(userids) > 1}
 
-        # Apply custom filter
-        filtered_users_data = {}
+        # Mark users with duplicate emails
+        for user_data in all_users_data:
+            user_data["has_duplicate_email"] = user_data["email"] in duplicates
 
-        for userid, user_data in all_users_data.items():
-            if self.filter_user(user_data):
-                filtered_users_data[userid] = user_data
+        # Sort: filtered users first (checked=True), then by userid
+        all_users_data.sort(key=lambda x: (not x["checked"], x["userid"]))
 
-        return all_users_data, filtered_users_data, duplicates
+        return all_users_data, duplicates
 
-    def _create_csv(self, users_data):
+    def _get_selected_userids(self):
+        """Get list of selected user IDs from request."""
+        selected = self.request.get("selected_users", "")
+        if not selected:
+            return []
+
+        # Handle both JSON array and form data
+        if selected.startswith("["):
+            return json.loads(selected)
+        return [uid.strip() for uid in selected.split(",") if uid.strip()]
+
+    def _download_csv(self):
+        """Generate and download CSV file with selected users."""
+        selected_userids = self._get_selected_userids()
+
+        if not selected_userids:
+            api.portal.show_message(_("No users selected for CSV download."), request=self.request, type="warning")
+            return self.request.RESPONSE.redirect(self.context.absolute_url() + "/@@signing-users-csv")
+
+        all_users_data, _ = self.get_users_data()
+
+        # Filter to only selected users
+        selected_users = [u for u in all_users_data if u["userid"] in selected_userids]
+
+        # Generate CSV
         csv_output = StringIO()
         writer = csv.DictWriter(
             csv_output,
             fieldnames=["userid", "email", "lastname", "firstname", "fullname"],
             delimiter=",",
-            quoting=csv.QUOTE_MINIMAL
+            quoting=csv.QUOTE_MINIMAL,
         )
         writer.writeheader()
-        for userid in users_data:
-            user_data = users_data[userid]
-            writer.writerow({
-                "userid": safe_encode(userid),
-                "email": safe_encode(user_data["email"]),
-                "lastname": safe_encode(user_data["lastname"]),
-                "firstname": safe_encode(user_data["firstname"]),
-                "fullname": safe_encode(user_data["fullname"]),
-            })
-        return csv_output.getvalue()
+        for user_data in selected_users:
+            writer.writerow(
+                {
+                    "userid": safe_encode(user_data["userid"]),
+                    "email": safe_encode(user_data["email"]),
+                    "lastname": safe_encode(user_data["lastname"]),
+                    "firstname": safe_encode(user_data["firstname"]),
+                    "fullname": safe_encode(user_data["fullname"]),
+                }
+            )
 
-    def _generate_csv(self, fn_first, apply_filter=True):
-        """Generate csv file
-
-        :param fn_first: Boolean indicating if firstname comes first
-        :param apply_filter: Boolean to apply or not the filter_user method
-        """
-        all_users_data, filtered_users_data, duplicates = self._collect_users_data(fn_first)
-        users_data = filtered_users_data if apply_filter else all_users_data
-        output = self._create_csv(users_data)
+        output = csv_output.getvalue()
         response = self.request.RESPONSE
         response.setHeader("Content-Type", "text/csv; charset=utf-8")
-        filename = "plone_users_list_filtered.csv" if apply_filter else "plone_users_list_all.csv"
-        response.setHeader("Content-Disposition", "attachment; filename={}".format(filename))
+        response.setHeader("Content-Disposition", "attachment; filename=signing_users_selected.csv")
         return output
 
-    def _generate_html(self, fn_first, apply_filter=True):
-        """Generate html output with duplicates."""
-        # Get all users and filtered users in one call
-        all_users_data, filtered_users_data, duplicates = self._collect_users_data(fn_first)
-        users_data = filtered_users_data if apply_filter else all_users_data
-        csv_text = self._create_csv(users_data)
+    def _send_emails(self):
+        """Send emails to selected users."""
+        selected_userids = self._get_selected_userids()
 
-        base_url = self.context.absolute_url() + "/@@signing-users-csv"
+        if not selected_userids:
+            api.portal.show_message(_("No users selected for email sending."), request=self.request, type="warning")
+            return self.request.RESPONSE.redirect(self.context.absolute_url() + "/@@signing-users-csv")
 
-        html = [
-            "<!DOCTYPE html>",
-            "<html><head>",
-            "<meta charset='utf-8'>",
-            "<title>Liste des utilisateurs Plone</title>",
-            "<style>",
-            "body { font-family: Arial, sans-serif; margin: 20px; }",
-            "h1 { color: #333; }",
-            "h2 { color: #666; margin-top: 10px; }",
-            ".error-section { background-color: #fff3cd; border: 1px solid #ffc107; padding: 5px; margin: 20px 0; "
-            "border-radius: 5px; }",
-            ".success-section { background-color: #d4edda; border: 1px solid #28a745; padding: 5px; margin: 20px 0; "
-            "border-radius: 5px; }",
-            ".duplicate { margin: 10px 0; padding: 10px; background-color: #f8d7da; border-left: 4px solid #dc3545; }",
-            ".duplicate strong { color: #721c24; }",
-            ".csv-content { background-color: #f5f5f5; border: 1px solid #ddd; padding: 15px; margin: 20px 0; "
-            "font-family: monospace; white-space: pre-wrap; overflow-x: auto; max-height: 400px; overflow-y: auto; }",
-            ".download-btn { display: inline-block; padding: 10px 20px; background-color: #007bff; color: white; "
-            "text-decoration: none; border-radius: 5px; margin: 0 0 10px; }",
-            ".download-btn:hover { background-color: #0056b3; }",
-            ".download-btn.secondary { background-color: #6c757d; }",
-            ".download-btn.secondary:hover { background-color: #5a6268; }",
-            ".stats { margin: 20px 0; }",
-            "</style>",
-            "</head><body>",
-            "<h1>Plone list users</h1>",
-            "<div class='stats'>",
-            "<p><strong>Total users (all) :</strong> {}</p>".format(len(all_users_data)),
-            "<p><strong>Total users (filtered) :</strong> {}</p>".format(len(filtered_users_data)),
-            "<p><strong>Total duplicated emails :</strong> {}</p>".format(len(duplicates)),
-            "</div>",
-        ]
-        if duplicates:
-            html.append("<div class='error-section'>")
-            html.append("<h2>⚠️ email duplicate</h2>")
-            for email, userids in sorted(duplicates.items()):
-                html.append("<div class='duplicate'>")
-                html.append("<strong>Email :</strong> {}<br>".format(safe_encode(email)))
-                html.append("<strong>Users :</strong> {}".format(", ".join([safe_encode(uid) for uid in userids])))
-                html.append("</div>")
-            html.append("</div>")
-        else:
-            html.append("<div class='success-section'>")
-            html.append("<h2>✓ No email duplicate</h2>")
-            html.append("</div>")
+        email_content = get_registry_signing_users_email_content()
+        if not email_content:
+            api.portal.show_message(
+                _("Email content is not configured in the settings."), request=self.request, type="error"
+            )
+            return self.request.RESPONSE.redirect(self.context.absolute_url() + "/@@signing-users-csv")
 
-        html.append("<h2>Download CSV file</h2>")
-        html.append("<a href='{}?download=1&apply_filter=1' class='download-btn'>📥 Download CSV "
-                    "(filtered)</a>".format(base_url))
-        html.append("<a href='{}?download=1&apply_filter=0' class='download-btn secondary'>📥 Download CSV "
-                    "(all users)</a>".format(base_url))
-        html.append("<h2>Overview of CSV file{}</h2>".format(" (filtered)" if apply_filter else ""))
-        html.append("<div class='csv-content'>{}</div>".format(csv_text.replace("<", "&lt;").replace(">", "&gt;")))
-        html.append("</body></html>")
+        all_users_data, duplicates = self.get_users_data()
+        selected_users = [u for u in all_users_data if u["userid"] in selected_userids]
 
-        response = self.request.RESPONSE
-        response.setHeader("Content-Type", "text/html; charset=utf-8")
+        portal_email = api.portal.get().getProperty("email_from_address")
+        if not portal_email:
+            api.portal.show_message(_("Portal from email is not configured."), request=self.request, type="error")
+            return self.request.RESPONSE.redirect(self.context.absolute_url() + "/@@mail-controlpanel")
 
-        return "\n".join(html)
+        success_count = 0
+        failed_count = 0
+        for user_data in selected_users:
+            if not user_data["email"]:
+                failed_count += 1
+                api.portal.show_message(
+                    _(
+                        "User ${userid} has no email address configured. Skipping.",
+                        mapping={"userid": user_data["userid"]},
+                    ),
+                    request=self.request,
+                    type="warning",
+                )
+                continue
+
+            personalized_content = str(email_content).format(**user_data).replace("\n", "<br>\n")
+
+            # Create and send email
+            try:
+                eml = create_html_email(personalized_content, with_plain=True)
+                subject = translate(_(u"You have been invited to Paraphéo"), context=self.request)
+
+                status, error = send_email(
+                    eml, subject=subject, mfrom=portal_email, mto=user_data["email"], immediate=False
+                )
+
+                if status:
+                    success_count += 1
+                else:
+                    raise Exception(error)
+            except Exception as e:
+                failed_count += 1
+                error = str(e)
+                api.portal.show_message(
+                    _(
+                        "Failed to send email to ${userid}.",
+                        mapping={"userid": user_data["userid"]},
+                    )
+                    + " "
+                    + error,
+                    request=self.request,
+                    type="error",
+                )
+                continue
+
+        if success_count > 0:
+            api.portal.show_message(
+                _("Emails sent successfully to ${count} users.", mapping={"count": success_count}),
+                request=self.request,
+                type="info",
+            )
+
+        if failed_count > 0:
+            api.portal.show_message(
+                _("Failed to send emails to ${count} users.", mapping={"count": failed_count}),
+                request=self.request,
+                type="warning",
+            )
+
+        return self.request.RESPONSE.redirect(self.context.absolute_url() + "/@@signing-users-csv")
 
 
 class EsignMacros(BrowserView):

--- a/src/imio/esign/browser/views.py
+++ b/src/imio/esign/browser/views.py
@@ -14,7 +14,6 @@ from imio.esign.utils import get_session_annotation
 from imio.esign.utils import remove_session
 from imio.helpers.content import uuidToObject
 from imio.helpers.emailer import create_html_email
-from imio.helpers.emailer import get_mail_host
 from imio.helpers.emailer import send_email
 from imio.helpers.security import separate_fullname
 from imio.prettylink.interfaces import IPrettyLink
@@ -24,10 +23,12 @@ from plone import api
 from plone.app.layout.viewlets import ViewletBase
 from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
+from Products.PageTemplates.Expressions import SecureModuleImporter
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.component import getMultiAdapter
 from zope.i18n import translate
 from zope.interface import implementer
+from zope.pagetemplate.pagetemplate import PageTemplate
 from zope.publisher.interfaces import IPublishTraverse
 
 import csv
@@ -500,7 +501,7 @@ class SigningUsersCsv(BrowserView):
             api.portal.show_message(_("No users selected for CSV download."), request=self.request, type="warning")
             return self.request.RESPONSE.redirect(self.context.absolute_url() + "/@@signing-users-csv")
 
-        all_users_data, _ = self.get_users_data()
+        all_users_data, __ = self.get_users_data()
 
         # Filter to only selected users
         selected_users = [u for u in all_users_data if u["userid"] in selected_userids]
@@ -569,7 +570,8 @@ class SigningUsersCsv(BrowserView):
                 )
                 continue
 
-            personalized_content = str(email_content).format(**user_data).replace("\n", "<br>\n")
+            personalized_content = self._render_email_content(email_content, user_data)
+            # personalized_content = str(email_content).format(**user_data).replace("\n", "<br>\n")
 
             # Create and send email
             try:
@@ -614,6 +616,29 @@ class SigningUsersCsv(BrowserView):
             )
 
         return self.request.RESPONSE.redirect(self.context.absolute_url() + "/@@signing-users-csv")
+
+    def _render_email_content(self, template, user_data):
+        """Render the email content template with user data.
+
+        :param template: The email content template (TAL compliant)
+        :param user_data: dict containing user data (userid, email, lastname, firstname, fullname)
+        :return: Rendered email content as a string
+        """
+        pt = PageTemplate()
+        pt.pt_source_file = lambda: "none"
+        pt.write(template)
+        namespace = pt.pt_getContext()
+        namespace.update(
+            {
+                "request": self.request,
+                "view": self,
+                "context": self.context,
+                "user_data": user_data,
+                "parapheo_url": ESIGN_ROOT_URL,
+                "modules": SecureModuleImporter,
+            }
+        )
+        return pt.pt_render(namespace)
 
 
 class EsignMacros(BrowserView):

--- a/src/imio/esign/browser/views.py
+++ b/src/imio/esign/browser/views.py
@@ -8,6 +8,7 @@ from imio.esign import manage_session_perm
 from imio.esign.browser.table import external_session_link
 from imio.esign.browser.table import SessionsTable
 from imio.esign.config import get_registry_enabled
+from imio.esign.config import get_registry_parapheo_url
 from imio.esign.config import get_registry_signing_users_email_content
 from imio.esign.utils import create_external_session
 from imio.esign.utils import get_session_annotation
@@ -634,7 +635,7 @@ class SigningUsersCsv(BrowserView):
                 "view": self,
                 "context": self.context,
                 "user_data": user_data,
-                "parapheo_url": ESIGN_ROOT_URL,
+                "parapheo_url": get_registry_parapheo_url(),
                 "modules": SecureModuleImporter,
             }
         )

--- a/src/imio/esign/browser/views.py
+++ b/src/imio/esign/browser/views.py
@@ -476,15 +476,21 @@ class SigningUsersCsv(BrowserView):
         return all_users_data, duplicates
 
     def _get_selected_userids(self):
-        """Get list of selected user IDs from request."""
+        """Get list of selected user IDs from request.
+
+        Expects a JSON-formatted list in 'selected_users' parameter.
+        Returns an empty list if the input is not valid JSON.
+        """
         selected = self.request.get("selected_users", "")
+
         if not selected:
             return []
 
-        # Handle both JSON array and form data
-        if selected.startswith("["):
+        # Parse JSON array
+        try:
             return json.loads(selected)
-        return [uid.strip() for uid in selected.split(",") if uid.strip()]
+        except (json.JSONDecodeError, ValueError, TypeError):
+            return []
 
     def _download_csv(self):
         """Generate and download CSV file with selected users."""
@@ -540,7 +546,7 @@ class SigningUsersCsv(BrowserView):
             )
             return self.request.RESPONSE.redirect(self.context.absolute_url() + "/@@signing-users-csv")
 
-        all_users_data, duplicates = self.get_users_data()
+        all_users_data, _duplicates = self.get_users_data()
         selected_users = [u for u in all_users_data if u["userid"] in selected_userids]
 
         portal_email = api.portal.get().getProperty("email_from_address")

--- a/src/imio/esign/config.py
+++ b/src/imio/esign/config.py
@@ -23,12 +23,16 @@ def get_registry_seal_email(default=""):
     return api.portal.get_registry_record("imio.esign.seal_email", default=default)
 
 
-def get_registry_signing_users_email_content(default=""):
-    return api.portal.get_registry_record("imio.esign.signing_users_email_content", default=default)
-
-
 def get_registry_sign_code(default=""):
     return api.portal.get_registry_record("imio.esign.sign_code", default=default)
+
+
+def get_registry_parapheo_url(default=""):
+    return api.portal.get_registry_record("imio.esign.parapheo_url", default=default)
+
+
+def get_registry_signing_users_email_content(default=""):
+    return api.portal.get_registry_record("imio.esign.signing_users_email_content", default=default)
 
 
 def set_registry_enabled(value):
@@ -55,5 +59,54 @@ def set_registry_sign_code(value):
     api.portal.set_registry_record("imio.esign.sign_code", value)
 
 
+def set_registry_parapheo_url(value):
+    api.portal.set_registry_record("imio.esign.parapheo_url", value)
+
+
 def set_registry_signing_users_email_content(value):
     api.portal.set_registry_record("imio.esign.signing_users_email_content", value)
+
+
+SIGNERS_EMAIL_CONTENT = u"""
+<meta charset="UTF-8"><tal:global>
+<p style="font-weight: bold;" tal:condition="nothing">!! Attention: ne pas modifier ceci directement mais passer
+par "Source" !!</p>
+
+<p>Bonjour <span tal:content="python: user_data['fullname']">FULLNAME</span>,</p>
+
+<p>Vous avez été défini comme signataire dans une application IMIO (iA.Delib, iA.Docs, etc.).
+<br />Avant de pouvoir signer des documents, vous devez activer votre compte auprès de Paraphéo.</p>
+
+<p>Pour ce faire, il est nécessaire de s'y connecter une toute première fois en suivant ces étapes:</p>
+
+<ol>
+<li>Vous rendre sur <a href="#" tal:attributes="href parapheo_url">Paraphéo</a></li>
+<li>Cliquer sur le mode de connexion "Portal d'authentification"</li>
+<li>Entrer votre adresse email "<span tal:content="python: user_data['email']">EMAIL</span>" et cliquer
+sur "Connexion"</li>
+</ol>
+
+<p>Si vous n'avez jamais défini votre mot de passe dans Wallonie Connect ou que vous l'avez oublié:</p>
+
+<ol>
+<li>Cliquer sur "Mot de passe oublié ?" (situé sous le champ "mot de passe")</li>
+<li>Entrer à nouveau votre email et cliquer sur "Soumettre"</li>
+<li>Consulter votre boîte mail qui doit contenir un mail intitulé "Réinitialiser le mot de passe"
+(vérifier les spams au cas ou...)</li>
+<li>Suivre les étapes pour configurer l'authentification par mobile</li>
+</ol>
+
+<p>En cas de besoin, n'hésitez pas à faire appel à votre référent interne Wallonie Connect !</p>
+
+<p>Une fois votre mot de passe défini, vous pouvez poursuivre l'identification sur le site Paraphéo:</p>
+
+<ol>
+<li>Si besoin, répéter les 3 premières étapes du premier paragraphe</li>
+<li>Entrer votre adresse email et&nbsp;votre mot de passe et cliquer sur "Connexion"</li>
+<li>Entrer votre "code à usage unique" depuis votre mobile et cliquer sur "Connexion"</li>
+<li>Une fois connecté dans Paraphéo, votre compte est validé et prêt à être utilisé dans une session de signature.</li>
+</ol>
+
+<p>Cordialement
+<br />L'équipe IMIO</p>
+</tal:global>"""

--- a/src/imio/esign/config.py
+++ b/src/imio/esign/config.py
@@ -23,6 +23,10 @@ def get_registry_seal_email(default=""):
     return api.portal.get_registry_record("imio.esign.seal_email", default=default)
 
 
+def get_registry_signing_users_email_content(default=""):
+    return api.portal.get_registry_record("imio.esign.signing_users_email_content", default=default)
+
+
 def get_registry_sign_code(default=""):
     return api.portal.get_registry_record("imio.esign.sign_code", default=default)
 
@@ -49,3 +53,7 @@ def set_registry_seal_email(value):
 
 def set_registry_sign_code(value):
     api.portal.set_registry_record("imio.esign.sign_code", value)
+
+
+def set_registry_signing_users_email_content(value):
+    api.portal.set_registry_record("imio.esign.signing_users_email_content", value)

--- a/src/imio/esign/setuphandlers.py
+++ b/src/imio/esign/setuphandlers.py
@@ -24,7 +24,7 @@ class HiddenProfiles(object):
 def post_install(context):
     """Post install script"""
     if not get_registry_parapheo_url():
-        set_registry_parapheo_url("https://simplycosi-1-test.trustsigneurope.com/login?tenantName=IMIO")
+        set_registry_parapheo_url(u"https://simplycosi-1-test.trustsigneurope.com/login?tenantName=IMIO")
     if not get_registry_signing_users_email_content():
         set_registry_signing_users_email_content(SIGNERS_EMAIL_CONTENT)
 

--- a/src/imio/esign/setuphandlers.py
+++ b/src/imio/esign/setuphandlers.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
-
-from plone import api
+from imio.esign.config import get_registry_parapheo_url
+from imio.esign.config import get_registry_signing_users_email_content
+from imio.esign.config import set_registry_parapheo_url
+from imio.esign.config import set_registry_signing_users_email_content
+from imio.esign.config import SIGNERS_EMAIL_CONTENT
 from Products.CMFPlone.interfaces import INonInstallable
 from zope.interface import implementer
 
@@ -20,7 +23,10 @@ class HiddenProfiles(object):
 
 def post_install(context):
     """Post install script"""
-    portal = api.portal.get()
+    if not get_registry_parapheo_url():
+        set_registry_parapheo_url("https://simplycosi-1-test.trustsigneurope.com/login?tenantName=IMIO")
+    if not get_registry_signing_users_email_content():
+        set_registry_signing_users_email_content(SIGNERS_EMAIL_CONTENT)
 
 
 def uninstall(context):

--- a/test-4.3.cfg
+++ b/test-4.3.cfg
@@ -76,6 +76,13 @@ pyrsistent = 0.15.7
 z3c.jbot = 1.1.0
 zipp = 1.2.0
 
+# Required by:
+# imio.helpers==1.3.11.dev0
+cryptography = 3.3.2
+cffi = 1.15.1
+ipaddress = 1.0.23
+pycparser = 2.21
+
 # Added by buildout at 2023-02-21 14:51:26.709124
 Products.DocFinderTab = 1.0.5
 aws.zope2zcmldoc = 1.1.0
@@ -143,4 +150,3 @@ Pygments = 2.5.2
 # beautifulsoup
 soupsieve = 1.9.2
 backports.functools-lru-cache = 1.5
-


### PR DESCRIPTION
Jen ai profité pour tester l'IA vu que c'est une vue qui ne devrait pas beaucoup évoluer et qui ne sera utilisée que pa nous. Je suis bien sûr repassé derrière

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Signing Users UI: selectable list, duplicate-email highlighting, bulk actions, CSV export, and send-email flow with confirmation modal and per-recipient reporting.
  * Send personalized emails to selected users; admin-configurable email template rendered with a WYSIWYG editor.
  * Admin setting to store a Parapheo URL for signing integration.

* **Chores**
  * Default initialization of the new settings on install.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->