### PR TITLE
Discriminate session size

### DIFF
--- a/src/imio/esign/browser/settings.py
+++ b/src/imio/esign/browser/settings.py
@@ -78,6 +78,22 @@ class IImioEsignSettings(Interface):
         required=False,
     )
 
+    max_session_size = schema.Int(
+        title=_("Max session size (MB)"),
+        description=_("Maximum size of the session in megabytes. If the total size of files to be signed exceeds this limit, a new session will be created."),
+        default=100,
+        min=1,
+        required=True,
+    )
+
+    max_file_size = schema.Int(
+        title=_("Max file size (MB)"),
+        description=_("Maximum size of a single file in megabytes. If a file exceeds this limit, it will be isolated in a single session."),
+        default=100,
+        min=1,
+        required=True,
+    )
+
 
 class ImioEsignSettings(RegistryEditForm):
     schema = IImioEsignSettings

--- a/src/imio/esign/browser/settings.py
+++ b/src/imio/esign/browser/settings.py
@@ -86,14 +86,6 @@ class IImioEsignSettings(Interface):
         required=True,
     )
 
-    max_file_size = schema.Int(
-        title=_("Max file size (MB)"),
-        description=_("Maximum size of a single file in megabytes. If a file exceeds this limit, it will be isolated in a single session."),
-        default=100,
-        min=1,
-        required=True,
-    )
-
 
 class ImioEsignSettings(RegistryEditForm):
     schema = IImioEsignSettings

--- a/src/imio/esign/config.py
+++ b/src/imio/esign/config.py
@@ -27,6 +27,14 @@ def get_registry_sign_code(default=""):
     return api.portal.get_registry_record("imio.esign.sign_code", default=default)
 
 
+def get_registry_max_session_size(default=100):
+    return api.portal.get_registry_record("imio.esign.max_session_size", default=default)
+
+
+def get_registry_max_file_size(default=100):
+    return api.portal.get_registry_record("imio.esign.max_file_size", default=default)
+
+
 def set_registry_enabled(value):
     api.portal.set_registry_record("imio.esign.enabled", value)
 
@@ -49,3 +57,11 @@ def set_registry_seal_email(value):
 
 def set_registry_sign_code(value):
     api.portal.set_registry_record("imio.esign.sign_code", value)
+
+
+def set_registry_max_session_size(value):
+    api.portal.set_registry_record("imio.esign.max_session_size", value)
+
+
+def set_registry_max_file_size(value):
+    api.portal.set_registry_record("imio.esign.max_file_size", value)

--- a/src/imio/esign/config.py
+++ b/src/imio/esign/config.py
@@ -31,10 +31,6 @@ def get_registry_max_session_size(default=100):
     return api.portal.get_registry_record("imio.esign.max_session_size", default=default)
 
 
-def get_registry_max_file_size(default=100):
-    return api.portal.get_registry_record("imio.esign.max_file_size", default=default)
-
-
 def set_registry_enabled(value):
     api.portal.set_registry_record("imio.esign.enabled", value)
 
@@ -61,7 +57,3 @@ def set_registry_sign_code(value):
 
 def set_registry_max_session_size(value):
     api.portal.set_registry_record("imio.esign.max_session_size", value)
-
-
-def set_registry_max_file_size(value):
-    api.portal.set_registry_record("imio.esign.max_file_size", value)

--- a/src/imio/esign/tests/test_utils.py
+++ b/src/imio/esign/tests/test_utils.py
@@ -2,8 +2,9 @@
 """utils tests for this package."""
 from datetime import date
 from datetime import timedelta
+from imio.esign.config import get_registry_max_session_size
 from imio.esign.config import set_registry_max_session_size
-from imio.esign.testing import IMIO_ESIGN_INTEGRATION_TESTING  # noqa: E501
+from imio.esign.testing import IMIO_ESIGN_INTEGRATION_TESTING
 from imio.esign.utils import add_files_to_session
 from imio.esign.utils import get_file_download_url
 from imio.esign.utils import get_filesize
@@ -260,6 +261,8 @@ class TestUtils(unittest.TestCase):
 
         # set session size just under the 1 MB limit so adding another file exceeds it
         session["size"] = 1 * 1024**2 - 1  # 1 MB - 1 byte
+        previous_max = get_registry_max_session_size()
+        self.addCleanup(set_registry_max_session_size, previous_max)
         set_registry_max_session_size(1)
 
         # adding a file (~7KB) would exceed 1 MB => new session created

--- a/src/imio/esign/tests/test_utils.py
+++ b/src/imio/esign/tests/test_utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """utils tests for this package."""
+from collective.iconifiedcategory.utils import calculate_category_id
 from datetime import date
 from datetime import timedelta
 from imio.esign.config import get_registry_max_session_size
@@ -14,6 +15,7 @@ from imio.esign.utils import get_session_info
 from imio.esign.utils import remove_context_from_session
 from imio.esign.utils import remove_files_from_session
 from imio.esign.utils import remove_session
+from imio.helpers.content import uuidToObject
 from imio.pyutils.utils import shortuid_decode_id
 from plone import api
 from plone.app.testing import setRoles
@@ -90,7 +92,7 @@ class TestUtils(unittest.TestCase):
                     type="annex",
                     id="annex{}".format(i),
                     title="Annex {}".format(i),
-                    content_category="to_sign",
+                    content_category=calculate_category_id(self.portal["annexes_types"]["annexes"]["to_sign"]),
                     scan_id="0123456000000{:02d}".format(i),
                     file=NamedBlobFile(data=f.read(), filename=u"annex{}.pdf".format(i), contentType="application/pdf"),
                 )
@@ -247,6 +249,19 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(get_filesize(self.uids[1]), 7014)
         # invalid UID returns 0
         self.assertEqual(get_filesize("nonexistent_uid"), 0)
+        # check size get robustness
+        annex = uuidToObject(uuid=self.uids[0], unrestricted=True)
+        self.assertEqual(annex.content_category, "plone-annexes_types_-_annexes_-_to_sign")
+        folder = annex.__parent__
+        self.assertEqual(folder.categorized_elements[self.uids[0]]["filesize"], 6968)
+        folder.categorized_elements[self.uids[0]]["filesize"] = 1111
+        self.assertEqual(get_filesize(self.uids[0]), 1111)
+        del folder.categorized_elements[self.uids[0]]["filesize"]
+        self.assertEqual(get_filesize(self.uids[0]), 6968)
+        del folder.categorized_elements[self.uids[0]]
+        self.assertEqual(get_filesize(self.uids[0]), 6968)
+        delattr(folder, "categorized_elements")
+        self.assertEqual(get_filesize(self.uids[0]), 6968)
 
     def test_session_size_discrimination(self):
         """Test that sessions are split when they would exceed max_session_size."""

--- a/src/imio/esign/tests/test_utils.py
+++ b/src/imio/esign/tests/test_utils.py
@@ -2,9 +2,11 @@
 """utils tests for this package."""
 from datetime import date
 from datetime import timedelta
+from imio.esign.config import set_registry_max_session_size
 from imio.esign.testing import IMIO_ESIGN_INTEGRATION_TESTING  # noqa: E501
 from imio.esign.utils import add_files_to_session
 from imio.esign.utils import get_file_download_url
+from imio.esign.utils import get_filesize
 from imio.esign.utils import get_max_download_date
 from imio.esign.utils import get_session_annotation
 from imio.esign.utils import get_session_info
@@ -133,6 +135,7 @@ class TestUtils(unittest.TestCase):
             ],
         )
         self.assertEqual(len(session["signers"]), 2)
+        self.assertEqual(session["size"], 6968)  # annex1.pdf
 
         # add files, no session_id => same session reused
         signers[1] = ("user2", "user2@sign.com", "User 2", "Position 2b")  # changed position => not discriminant
@@ -146,6 +149,7 @@ class TestUtils(unittest.TestCase):
         self.assertIn(self.folders[1].UID(), annot["c_uids"])
         self.assertEqual(len(session["files"]), 2)
         self.assertEqual(len(annot["c_uids"][self.folders[1].UID()]), 1)
+        self.assertEqual(session["size"], 6968 + 7014)  # annex1 + annex2
 
         # add files, no session_id, new discriminations => new session
         sid, session = add_files_to_session(signers, (self.uids[2],), discriminators=("council1",))
@@ -212,6 +216,7 @@ class TestUtils(unittest.TestCase):
         remove_files_from_session((self.uids[0], self.uids[1]))  # 2 of 3 session files
         self.assertEqual(len(annot["uids"]), 10)
         self.assertEqual(len(annot["sessions"][0]["files"]), 1)
+        self.assertEqual(annot["sessions"][0]["size"], 7014)  # only uid[5] (annex2) remains
         self.assertEqual(len(annot["c_uids"][self.folders[0].UID()]), 5)
         self.assertEqual(len(annot["c_uids"][self.folders[1].UID()]), 5)
         remove_files_from_session((self.uids[5],))  # no more session files, session removed
@@ -232,6 +237,42 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(len(annot["uids"]), 0)
         self.assertEqual(len(annot["c_uids"]), 0)
         self.assertEqual(len(annot["sessions"]), 0)
+
+    def test_get_filesize(self):
+        """Test get_filesize returns the correct file size."""
+        # even index => annex1.pdf (6968 bytes)
+        self.assertEqual(get_filesize(self.uids[0]), 6968)
+        # odd index => annex2.pdf (7014 bytes)
+        self.assertEqual(get_filesize(self.uids[1]), 7014)
+        # invalid UID returns 0
+        self.assertEqual(get_filesize("nonexistent_uid"), 0)
+
+    def test_session_size_discrimination(self):
+        """Test that sessions are split when they would exceed max_session_size."""
+        signers = [
+            ("user1", "user1@sign.com", "User 1", "Position 1"),
+        ]
+
+        # add one file to create a session (annex1.pdf = 6968 bytes)
+        sid, session = add_files_to_session(signers, (self.uids[0],))
+        self.assertEqual(sid, 0)
+        self.assertEqual(session["size"], 6968)
+
+        # set session size just under the 1 MB limit so adding another file exceeds it
+        session["size"] = 1 * 1024**2 - 1  # 1 MB - 1 byte
+        set_registry_max_session_size(1)
+
+        # adding a file (~7KB) would exceed 1 MB => new session created
+        sid2, session2 = add_files_to_session(signers, (self.uids[1],))
+        self.assertEqual(sid2, 1)
+        self.assertIsNot(session2, session)
+        self.assertEqual(session2["size"], 7014)
+
+        # with enough room, files go to the same session
+        sid3, session3 = add_files_to_session(signers, (self.uids[2],))
+        self.assertEqual(sid3, 1)
+        self.assertIs(session3, session2)
+        self.assertEqual(session3["size"], 7014 + 6968)
 
     def test_add_files_with_duplicate_filenames(self):
         """Test that files with duplicate filenames are renamed with suffix."""

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -377,6 +377,7 @@ def remove_files_from_session(files_uids):
             logger.error("Session %s not found", session_id)
             continue
         session = sessions[session_id]
+        session["size"] = max(0, session.get("size", 0) - get_filesize(uid))
         i = 0
         context_uid = None
         for j, dic in enumerate(session["files"]):

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -31,9 +31,21 @@ SESSION_URL = "imio/esign/v1/luxtrust/sessions"
 
 
 def get_filesize(uid):
+    """Get the file size of an annex.
+
+    :param uid: The UID of the annex.
+    :return: The file size in bytes, or 0 if not found.
+    """
     annex = uuidToObject(uuid=uid, unrestricted=True)
-    if hasattr(annex.__parent__, "categorized_elements"):
-        return annex.__parent__.categorized_elements.get(uid, {}).get("filesize", 0)
+    if not annex:
+        logger.error("Annex with UID %s not found.", uid)
+        return 0
+    if (
+        hasattr(annex.__parent__, "categorized_elements")
+        and uid in annex.__parent__.categorized_elements
+        and "filesize" in annex.__parent__.categorized_elements[uid]
+    ):
+        return annex.__parent__.categorized_elements[uid]["filesize"]
     return annex.file.size
 
 

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -6,6 +6,8 @@ from imio.esign import ESIGN_CREDENTIALS
 from imio.esign import ESIGN_ROOT_URL
 from imio.esign import logger
 from imio.esign.config import get_registry_file_url
+from imio.esign.config import get_registry_max_file_size
+from imio.esign.config import get_registry_max_session_size
 from imio.esign.config import get_registry_seal_code
 from imio.esign.config import get_registry_seal_email
 from imio.esign.config import get_registry_sign_code
@@ -29,8 +31,15 @@ import json
 SESSION_URL = "imio/esign/v1/luxtrust/sessions"
 
 
+def get_filesize(uid):
+    annex = uuidToObject(uuid=uid, unrestricted=True)
+    if hasattr(annex.__parent__, "categorized_elements"):
+        return annex.__parent__.categorized_elements.get(uid, {}).get("filesize", 0)
+    return annex.file.size
+
+
 def add_files_to_session(
-    signers, files_uids, seal=None, acroform=True, session_id=None, title=None, discriminators=(), watchers=(),
+    signers, files_uids, seal=None, acroform=True, session_id=None, title="", discriminators=(), watchers=(),
     create_session_custom_data=None
 ):
     """Add files to a session with the given signers.
@@ -47,6 +56,7 @@ def add_files_to_session(
     :return: session_id, session
     """
     annot = get_session_annotation()
+    session_ids = []
     if session_id is not None:
         if session_id not in annot["sessions"]:
             logger.error("Session with id %s not found in esign annotations.", session_id)
@@ -54,13 +64,36 @@ def add_files_to_session(
         else:
             session = annot["sessions"][session_id]
     else:
-        session_id, session = discriminate_sessions(signers, seal, acroform, discriminators=discriminators)
+        size = 0
+        exceeding_session_size_files_uids = []
+        for uid in files_uids.copy():
+            file_size = get_filesize(uid)
+            if file_size > get_registry_max_file_size() * 1024**2:
+                logger.warning("File UID %s with size %s exceeds the maximum file size limit, it will be isolated in a single session.", uid, file_size)
+                files_uids.remove(uid)
+                session_ids.extend(add_files_to_session(
+                    signers, [uid], seal=seal, acroform=acroform, title=title, discriminators=discriminators, watchers=watchers,
+                    create_session_custom_data=create_session_custom_data,
+                ))
+            elif size + file_size > get_registry_max_session_size() * 1024**2:
+                logger.warning("Adding file UID %s with size %s exceeds the maximum session size limit, a new session will be created for this file.", uid, file_size)
+                exceeding_session_size_files_uids.append(uid)
+                files_uids.remove(uid)
+            else:
+                size += file_size
+        if exceeding_session_size_files_uids:
+            session_ids.extend(add_files_to_session(
+                signers, exceeding_session_size_files_uids, seal=seal, acroform=acroform, title=title, discriminators=discriminators, watchers=watchers,
+                create_session_custom_data=create_session_custom_data,
+            ))
+        session_id, session = discriminate_sessions(signers, seal, acroform, discriminators=discriminators, size=size)
     if not session:
         session_id, session = create_session(
-            signers, seal, acroform=acroform, title=title or "", annot=annot, discriminators=discriminators,
+            signers, seal, acroform=acroform, title=title, annot=annot, discriminators=discriminators, size=size,
             watchers=watchers,
             create_session_custom_data=create_session_custom_data,
         )
+    session_ids.append(session_id)
     existing_files = [path.splitext(f["filename"])[0] for f in session["files"]]
     for uid in files_uids:
         annex = uuidToObject(uuid=uid, unrestricted=True)
@@ -68,6 +101,7 @@ def add_files_to_session(
         context_uid = context_uid_provider.get_context_uid()
         filename, ext = path.splitext(annex.file.filename or "no_filename.pdf")
         new_filename = get_correct_id(existing_files, filename)
+        session["size"] = session.get("size", 0) + get_filesize(uid)
         session["files"].append(
             {
                 "scan_id": annex.scan_id,
@@ -91,7 +125,7 @@ def add_files_to_session(
             session["title"] = session["title"].replace(u"{session_id}", str(session_id))
     session["last_update"] = datetime.now()
     annot._p_changed = True
-    return session_id, session
+    return session_ids
 
 
 def create_external_session(session_id, b64_cred=None, esign_root_url=None):
@@ -172,7 +206,7 @@ def create_external_session(session_id, b64_cred=None, esign_root_url=None):
     return ret
 
 
-def create_session(signers, seal=False, acroform=True, title=None, annot=None, discriminators=(), watchers=(),
+def create_session(signers, seal=False, acroform=True, title=None, annot=None, discriminators=(), size=0, watchers=(),
                    create_session_custom_data=None):
     """Create a session with the given signers and seal.
 
@@ -182,6 +216,7 @@ def create_session(signers, seal=False, acroform=True, title=None, annot=None, d
     :param title: title of the session
     :param annot: esign annotation, if not provided it will be fetched
     :param discriminators: optional list of string discriminators
+    :param size: size in bytes of the files to be added to the session
     :param watchers: optional list of external esign session watchers emails
     :param create_session_custom_data: optional custom dict of custom session data
     :return: session id and session information
@@ -197,6 +232,7 @@ def create_session(signers, seal=False, acroform=True, title=None, annot=None, d
         "client_id": None,
         "discriminators": discriminators,
         "files": PersistentList(),
+        "size": size,
         "last_update": datetime.now(),
         "seal": seal,
         "sign_id": None,
@@ -218,13 +254,14 @@ def create_session(signers, seal=False, acroform=True, title=None, annot=None, d
     return session_id, sessions[session_id]
 
 
-def discriminate_sessions(signers, seal, acroform, discriminators=(), annot=None):
+def discriminate_sessions(signers, seal, acroform, discriminators=(), annot=None, size=0):
     """Discriminate sessions based on seal value and signers in the same order.
 
     :param signers: a list of signers, each is a tuple with userid and email
     :param seal: seal boolean
     :param acroform: boolean value indicating if acroform is used
     :param discriminators: optional list of string discriminators
+    :param size: size in bytes of the files to be added to the session
     :param annot: esign annotation, if not provided it will be fetched
     :return: session id and session if found, or (None, None) if no session found
     """
@@ -241,6 +278,8 @@ def discriminate_sessions(signers, seal, acroform, discriminators=(), annot=None
             continue
         session_signers = session.get("signers", [])
         if len(signers) != len(session_signers):
+            continue
+        if size + session.get("size", 0) > get_registry_max_session_size() * 1024**2:
             continue
 
         if set(discriminators) != set(session.get("discriminators", ())):

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -40,13 +40,7 @@ def get_filesize(uid):
     if not annex:
         logger.error("Annex with UID %s not found.", uid)
         return 0
-    if (
-        hasattr(annex.__parent__, "categorized_elements")
-        and uid in annex.__parent__.categorized_elements
-        and "filesize" in annex.__parent__.categorized_elements[uid]
-    ):
-        return annex.__parent__.categorized_elements[uid]["filesize"]
-    return annex.file.size
+    return getattr(annex.__parent__, "categorized_elements", {}).get(uid, {}).get("filesize", annex.file.size)
 
 
 def add_files_to_session(

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -254,6 +254,7 @@ def discriminate_sessions(signers, seal, acroform, discriminators=(), annot=None
     if not annot:
         annot = get_session_annotation()
     sessions = annot.get("sessions", {})
+    max_session_size = get_registry_max_session_size() * 1024**2
 
     for session_id, session in sessions.items():
         if session["state"] != "draft":
@@ -265,7 +266,7 @@ def discriminate_sessions(signers, seal, acroform, discriminators=(), annot=None
         session_signers = session.get("signers", [])
         if len(signers) != len(session_signers):
             continue
-        if size + session.get("size", 0) > get_registry_max_session_size() * 1024**2:
+        if size + session.get("size", 0) > max_session_size:
             continue
 
         if set(discriminators) != set(session.get("discriminators", ())):

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -6,7 +6,6 @@ from imio.esign import ESIGN_CREDENTIALS
 from imio.esign import ESIGN_ROOT_URL
 from imio.esign import logger
 from imio.esign.config import get_registry_file_url
-from imio.esign.config import get_registry_max_file_size
 from imio.esign.config import get_registry_max_session_size
 from imio.esign.config import get_registry_seal_code
 from imio.esign.config import get_registry_seal_email
@@ -56,7 +55,7 @@ def add_files_to_session(
     :return: session_id, session
     """
     annot = get_session_annotation()
-    session_ids = []
+    size = sum(get_filesize(uid) for uid in files_uids)
     if session_id is not None:
         if session_id not in annot["sessions"]:
             logger.error("Session with id %s not found in esign annotations.", session_id)
@@ -64,36 +63,14 @@ def add_files_to_session(
         else:
             session = annot["sessions"][session_id]
     else:
-        size = 0
-        exceeding_session_size_files_uids = []
-        for uid in files_uids.copy():
-            file_size = get_filesize(uid)
-            if file_size > get_registry_max_file_size() * 1024**2:
-                logger.warning("File UID %s with size %s exceeds the maximum file size limit, it will be isolated in a single session.", uid, file_size)
-                files_uids.remove(uid)
-                session_ids.extend(add_files_to_session(
-                    signers, [uid], seal=seal, acroform=acroform, title=title, discriminators=discriminators, watchers=watchers,
-                    create_session_custom_data=create_session_custom_data,
-                ))
-            elif size + file_size > get_registry_max_session_size() * 1024**2:
-                logger.warning("Adding file UID %s with size %s exceeds the maximum session size limit, a new session will be created for this file.", uid, file_size)
-                exceeding_session_size_files_uids.append(uid)
-                files_uids.remove(uid)
-            else:
-                size += file_size
-        if exceeding_session_size_files_uids:
-            session_ids.extend(add_files_to_session(
-                signers, exceeding_session_size_files_uids, seal=seal, acroform=acroform, title=title, discriminators=discriminators, watchers=watchers,
-                create_session_custom_data=create_session_custom_data,
-            ))
         session_id, session = discriminate_sessions(signers, seal, acroform, discriminators=discriminators, size=size)
     if not session:
         session_id, session = create_session(
-            signers, seal, acroform=acroform, title=title, annot=annot, discriminators=discriminators, size=size,
+            signers, seal, acroform=acroform, title=title, annot=annot, discriminators=discriminators,
             watchers=watchers,
             create_session_custom_data=create_session_custom_data,
         )
-    session_ids.append(session_id)
+    session["size"] = session.get("size", 0) + size
     existing_files = [path.splitext(f["filename"])[0] for f in session["files"]]
     for uid in files_uids:
         annex = uuidToObject(uuid=uid, unrestricted=True)
@@ -101,7 +78,6 @@ def add_files_to_session(
         context_uid = context_uid_provider.get_context_uid()
         filename, ext = path.splitext(annex.file.filename or "no_filename.pdf")
         new_filename = get_correct_id(existing_files, filename)
-        session["size"] = session.get("size", 0) + get_filesize(uid)
         session["files"].append(
             {
                 "scan_id": annex.scan_id,
@@ -125,7 +101,7 @@ def add_files_to_session(
             session["title"] = session["title"].replace(u"{session_id}", str(session_id))
     session["last_update"] = datetime.now()
     annot._p_changed = True
-    return session_ids
+    return session_id, session
 
 
 def create_external_session(session_id, b64_cred=None, esign_root_url=None):
@@ -206,7 +182,7 @@ def create_external_session(session_id, b64_cred=None, esign_root_url=None):
     return ret
 
 
-def create_session(signers, seal=False, acroform=True, title=None, annot=None, discriminators=(), size=0, watchers=(),
+def create_session(signers, seal=False, acroform=True, title=None, annot=None, discriminators=(), watchers=(),
                    create_session_custom_data=None):
     """Create a session with the given signers and seal.
 
@@ -216,7 +192,6 @@ def create_session(signers, seal=False, acroform=True, title=None, annot=None, d
     :param title: title of the session
     :param annot: esign annotation, if not provided it will be fetched
     :param discriminators: optional list of string discriminators
-    :param size: size in bytes of the files to be added to the session
     :param watchers: optional list of external esign session watchers emails
     :param create_session_custom_data: optional custom dict of custom session data
     :return: session id and session information
@@ -232,7 +207,6 @@ def create_session(signers, seal=False, acroform=True, title=None, annot=None, d
         "client_id": None,
         "discriminators": discriminators,
         "files": PersistentList(),
-        "size": size,
         "last_update": datetime.now(),
         "seal": seal,
         "sign_id": None,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable maximum session size (default 100 MB) added to settings.
  * Exposed controls to get/set the max session size.
  * Sessions now track aggregated file sizes and enforce the configured limit when adding files.
  * File additions are distributed across sessions to respect size limits; removing files updates session size accordingly.

* **Tests**
  * Added tests validating file-size computation, session size tracking, and session allocation when limits are reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->