### PR TITLE
Added action to remove a single item from session

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 
 - Replaced external_session_link p by span.
   [sgeulette]
+- Added action to remove a single item from session.
+  [chris-adam]
 
 1.0a2 (2026-02-06)
 ------------------

--- a/src/imio/esign/browser/actions.py
+++ b/src/imio/esign/browser/actions.py
@@ -2,6 +2,7 @@
 from imio.esign import _
 from imio.esign.adapters import ISignable
 from imio.esign.utils import add_files_to_session
+from imio.esign.utils import get_session_annotation
 from imio.esign.utils import remove_context_from_session
 from imio.esign.utils import remove_files_from_session
 from plone import api
@@ -118,4 +119,5 @@ class RemoveItemFromSessionView(BrowserView):
 
     def available(self):
         """Defines if the action is available or not."""
-        return True
+        annot = get_session_annotation()
+        return self.context.UID() in annot.get("uids", {})

--- a/src/imio/esign/browser/actions.py
+++ b/src/imio/esign/browser/actions.py
@@ -3,6 +3,7 @@ from imio.esign import _
 from imio.esign.adapters import ISignable
 from imio.esign.utils import add_files_to_session
 from imio.esign.utils import remove_context_from_session
+from imio.esign.utils import remove_files_from_session
 from plone import api
 from Products.Five import BrowserView
 
@@ -98,3 +99,23 @@ class RemoveFromSessionView(BrowserView):
     def get_uid_to_remove(self):
         """ """
         return self.context.UID()
+
+
+class RemoveItemFromSessionView(BrowserView):
+    """View to remove an item from an esign session."""
+
+    def __init__(self, context, request):
+        super(RemoveItemFromSessionView, self).__init__(context, request)
+
+    def _finished(self):
+        msg = _("Element removed from session!")
+        api.portal.show_message(msg, request=self.request)
+        self.request.RESPONSE.redirect(self.context.absolute_url())
+
+    def index(self):
+        remove_files_from_session(files_uids=[self.context.UID()])
+        self._finished()
+
+    def available(self):
+        """Defines if the action is available or not."""
+        return True

--- a/src/imio/esign/browser/configure.zcml
+++ b/src/imio/esign/browser/configure.zcml
@@ -103,6 +103,15 @@
             i18n:domain="imio.esign"
     />
 
+    <browser:view
+            name="remove-item-from-esign-session"
+            for="*"
+            class=".actions.RemoveItemFromSessionView"
+            permission="imio.esign.ManageSessions"
+            i18n:domain="imio.esign"
+            allowed_attributes="available"
+    />
+
     <browser:page
             name="signing-users-csv"
             for="Products.CMFPlone.interfaces.IPloneSiteRoot"

--- a/src/imio/esign/browser/settings.py
+++ b/src/imio/esign/browser/settings.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from imio.esign import _
-from plone import api
 from plone.app.registry.browser.controlpanel import ControlPanelFormWrapper
 from plone.app.registry.browser.controlpanel import RegistryEditForm
-from plone.registry.interfaces import IRecordModifiedEvent
 from plone.z3cform import layout
 from zope import schema
 from zope.interface import Interface

--- a/src/imio/esign/profiles/default/actions.xml
+++ b/src/imio/esign/profiles/default/actions.xml
@@ -24,6 +24,17 @@
    </property>
    <property name="visible">True</property>
   </object>
+  <object name="remove_item_from_esign_session" meta_type="CMF Action" i18n:domain="imio.esign">
+   <property name="title" i18n:translate="">Remove item from esign session</property>
+   <property name="description" i18n:translate="">This will remove this element from the relevant esign session</property>
+   <property name="url_expr">string:${object/absolute_url}/@@remove-item-from-esign-session</property>
+   <property name="icon_expr"></property>
+   <property name="available_expr">object/@@remove-item-from-esign-session/available</property>
+   <property name="permissions">
+    <element value="Manage portal"/>
+   </property>
+   <property name="visible">True</property>
+  </object>
  </object>
  <object name="portal_tabs" meta_type="CMF Action Category">
   <object name="parapheo" meta_type="CMF Action">

--- a/src/imio/esign/setuphandlers.py
+++ b/src/imio/esign/setuphandlers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from plone import api
 from Products.CMFPlone.interfaces import INonInstallable
 from zope.interface import implementer
 
@@ -20,7 +19,6 @@ class HiddenProfiles(object):
 
 def post_install(context):
     """Post install script"""
-    portal = api.portal.get()
 
 
 def uninstall(context):

--- a/src/imio/esign/tests/test_actions.py
+++ b/src/imio/esign/tests/test_actions.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+"""actions tests for this package."""
+from imio.esign.testing import IMIO_ESIGN_INTEGRATION_TESTING
+from imio.esign.utils import add_files_to_session
+from imio.esign.utils import get_session_annotation
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.namedfile.file import NamedBlobFile
+from plone.namedfile.file import NamedBlobImage
+from Products.statusmessages.interfaces import IStatusMessage
+from zope.component import getMultiAdapter
+
+import collective.iconifiedcategory
+import os
+import unittest
+
+
+class TestRemoveItemFromSessionView(unittest.TestCase):
+    """Test RemoveItemFromSessionView browser view."""
+
+    layer = IMIO_ESIGN_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.portal.REQUEST
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        # add content category configuration
+        at_folder = api.content.create(
+            container=self.portal,
+            id="annexes_types",
+            title="Annexes Types",
+            type="ContentCategoryConfiguration",
+            exclude_from_nav=True,
+        )
+        category_group = api.content.create(
+            type="ContentCategoryGroup",
+            title="Annexes",
+            container=at_folder,
+            id="annexes",
+        )
+        icon_path = os.path.join(os.path.dirname(collective.iconifiedcategory.__file__), "tests", "icône1.png")
+        with open(icon_path, "rb") as fl:
+            api.content.create(
+                type="ContentCategory",
+                title="To sign",
+                container=category_group,
+                icon=NamedBlobImage(fl.read(), filename=u"icône1.png"),
+                id="to_sign",
+                predefined_title="To be signed",
+                to_sign=True,
+                show_preview=False,
+            )
+        # add users and annexes
+        api.user.create(email="user1@sign.com", username="user1", password="password1")
+        self.folder = api.content.create(
+            container=self.portal, type="Folder", id="test_folder", title="Test Folder"
+        )
+        tests_dir = os.path.dirname(__file__)
+        self.annexes = []
+        for i in range(3):
+            with open(os.path.join(tests_dir, "annex1.pdf"), "rb") as f:
+                annex = api.content.create(
+                    container=self.folder,
+                    type="annex",
+                    id="annex{}".format(i),
+                    title="Annex {}".format(i),
+                    content_category="to_sign",
+                    scan_id="0123456000000{:02d}".format(i),
+                    file=NamedBlobFile(data=f.read(), filename=u"annex{}.pdf".format(i), contentType="application/pdf"),
+                )
+                self.annexes.append(annex)
+        self.signers = [("user1", "user1@sign.com", "User 1", "Position 1")]
+
+    def test_available(self):
+        """Test available method returns True."""
+        view = getMultiAdapter((self.annexes[0], self.request), name="remove-item-from-esign-session")
+        self.assertFalse(view.available())
+
+        uids = [a.UID() for a in self.annexes]
+        add_files_to_session(self.signers, uids)
+        self.assertTrue(view.available())
+
+    def test_index_removes_file_from_session(self):
+        """Test index() removes the file from the esign session."""
+        annot = get_session_annotation()
+        # Add files to a session
+        uids = [a.UID() for a in self.annexes]
+        add_files_to_session(self.signers, uids)
+        self.assertEqual(len(annot["sessions"]), 1)
+        self.assertEqual(len(annot["uids"]), 3)
+        session = annot["sessions"][0]
+        self.assertEqual(len(session["files"]), 3)
+
+        # Remove one file via the view
+        view = getMultiAdapter((self.annexes[0], self.request), name="remove-item-from-esign-session")
+        view.index()
+        # The file should be removed from the session
+        self.assertNotIn(uids[0], annot["uids"])
+        self.assertEqual(len(annot["uids"]), 2)
+        self.assertEqual(len(session["files"]), 2)
+        remaining_uids = [f["uid"] for f in session["files"]]
+        self.assertNotIn(uids[0], remaining_uids)
+        self.assertIn(uids[1], remaining_uids)
+        self.assertIn(uids[2], remaining_uids)
+
+    def test_index_removes_last_file_removes_session(self):
+        """Test removing the last file from a session also removes the session."""
+        annot = get_session_annotation()
+        uids = [self.annexes[0].UID()]
+        add_files_to_session(self.signers, uids)
+        self.assertEqual(len(annot["sessions"]), 1)
+
+        view = getMultiAdapter((self.annexes[0], self.request), name="remove-item-from-esign-session")
+        view.index()
+        self.assertEqual(len(annot["sessions"]), 0)
+        self.assertEqual(len(annot["uids"]), 0)
+
+    def test_finished_shows_message_and_redirects(self):
+        """Test _finished sets a status message and redirects."""
+        view = getMultiAdapter((self.annexes[0], self.request), name="remove-item-from-esign-session")
+        view._finished()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertIn("removed from session", messages[0].message)
+        self.assertEqual(self.request.RESPONSE.getHeader("location"), self.annexes[0].absolute_url())

--- a/src/imio/esign/tests/test_actions.py
+++ b/src/imio/esign/tests/test_actions.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """actions tests for this package."""
+from collective.iconifiedcategory.utils import calculate_category_id
 from imio.esign.testing import IMIO_ESIGN_INTEGRATION_TESTING
 from imio.esign.utils import add_files_to_session
 from imio.esign.utils import get_session_annotation
@@ -65,7 +66,7 @@ class TestRemoveItemFromSessionView(unittest.TestCase):
                     type="annex",
                     id="annex{}".format(i),
                     title="Annex {}".format(i),
-                    content_category="to_sign",
+                    content_category=calculate_category_id(self.portal["annexes_types"]["annexes"]["to_sign"]),
                     scan_id="0123456000000{:02d}".format(i),
                     file=NamedBlobFile(data=f.read(), filename=u"annex{}.pdf".format(i), contentType="application/pdf"),
                 )
@@ -76,7 +77,6 @@ class TestRemoveItemFromSessionView(unittest.TestCase):
         """Test available method returns True."""
         view = getMultiAdapter((self.annexes[0], self.request), name="remove-item-from-esign-session")
         self.assertFalse(view.available())
-
         uids = [a.UID() for a in self.annexes]
         add_files_to_session(self.signers, uids)
         self.assertTrue(view.available())

--- a/src/imio/esign/tests/test_browser_views.py
+++ b/src/imio/esign/tests/test_browser_views.py
@@ -4,6 +4,9 @@ from datetime import datetime
 from datetime import timedelta
 from imio.esign.browser.views import DownloadFileView
 from imio.esign.testing import IMIO_ESIGN_FUNCTIONAL_TESTING
+from imio.esign.testing import IMIO_ESIGN_INTEGRATION_TESTING
+from imio.esign.utils import add_files_to_session
+from imio.esign.utils import get_session_annotation
 from imio.pyutils.utils import shortuid_encode_id
 from plone import api
 from plone.app.testing import logout
@@ -12,6 +15,8 @@ from plone.app.testing import TEST_USER_ID
 from plone.namedfile.file import NamedBlobFile
 from plone.namedfile.file import NamedBlobImage
 from plone.testing import z2
+from Products.statusmessages.interfaces import IStatusMessage
+from zope.component import getMultiAdapter
 
 import collective.iconifiedcategory
 import os
@@ -157,3 +162,109 @@ class TestDownloadFileView(unittest.TestCase):
         self.assertIn("The corresponding file identifier cannot be retrieved (aabbccddee)", browser.contents)
         browser.open("{}/download-file/{}".format(portal_url, "aabbccddee?param=value"))
         self.assertIn("The corresponding file identifier cannot be retrieved (aabbccddee)", browser.contents)
+
+
+class TestRemoveItemFromSessionView(unittest.TestCase):
+    """Test RemoveItemFromSessionView browser view."""
+
+    layer = IMIO_ESIGN_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.portal.REQUEST
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        # add content category configuration
+        at_folder = api.content.create(
+            container=self.portal,
+            id="annexes_types",
+            title="Annexes Types",
+            type="ContentCategoryConfiguration",
+            exclude_from_nav=True,
+        )
+        category_group = api.content.create(
+            type="ContentCategoryGroup",
+            title="Annexes",
+            container=at_folder,
+            id="annexes",
+        )
+        icon_path = os.path.join(os.path.dirname(collective.iconifiedcategory.__file__), "tests", "icône1.png")
+        with open(icon_path, "rb") as fl:
+            api.content.create(
+                type="ContentCategory",
+                title="To sign",
+                container=category_group,
+                icon=NamedBlobImage(fl.read(), filename=u"icône1.png"),
+                id="to_sign",
+                predefined_title="To be signed",
+                to_sign=True,
+                show_preview=False,
+            )
+        # add users and annexes
+        api.user.create(email="user1@sign.com", username="user1", password="password1")
+        self.folder = api.content.create(
+            container=self.portal, type="Folder", id="test_folder", title="Test Folder"
+        )
+        tests_dir = os.path.dirname(__file__)
+        self.annexes = []
+        for i in range(3):
+            with open(os.path.join(tests_dir, "annex1.pdf"), "rb") as f:
+                annex = api.content.create(
+                    container=self.folder,
+                    type="annex",
+                    id="annex{}".format(i),
+                    title="Annex {}".format(i),
+                    content_category="to_sign",
+                    scan_id="0123456000000{:02d}".format(i),
+                    file=NamedBlobFile(data=f.read(), filename=u"annex{}.pdf".format(i), contentType="application/pdf"),
+                )
+                self.annexes.append(annex)
+        self.signers = [("user1", "user1@sign.com", "User 1", "Position 1")]
+
+    def test_available(self):
+        """Test available method returns True."""
+        view = getMultiAdapter((self.annexes[0], self.request), name="remove-item-from-esign-session")
+        self.assertTrue(view.available())
+
+    def test_index_removes_file_from_session(self):
+        """Test index() removes the file from the esign session."""
+        annot = get_session_annotation()
+        # Add files to a session
+        uids = [a.UID() for a in self.annexes]
+        add_files_to_session(self.signers, uids)
+        self.assertEqual(len(annot["sessions"]), 1)
+        self.assertEqual(len(annot["uids"]), 3)
+        session = annot["sessions"][0]
+        self.assertEqual(len(session["files"]), 3)
+
+        # Remove one file via the view
+        view = getMultiAdapter((self.annexes[0], self.request), name="remove-item-from-esign-session")
+        view.index()
+        # The file should be removed from the session
+        self.assertNotIn(uids[0], annot["uids"])
+        self.assertEqual(len(annot["uids"]), 2)
+        self.assertEqual(len(session["files"]), 2)
+        remaining_uids = [f["uid"] for f in session["files"]]
+        self.assertNotIn(uids[0], remaining_uids)
+        self.assertIn(uids[1], remaining_uids)
+        self.assertIn(uids[2], remaining_uids)
+
+    def test_index_removes_last_file_removes_session(self):
+        """Test removing the last file from a session also removes the session."""
+        annot = get_session_annotation()
+        uids = [self.annexes[0].UID()]
+        add_files_to_session(self.signers, uids)
+        self.assertEqual(len(annot["sessions"]), 1)
+
+        view = getMultiAdapter((self.annexes[0], self.request), name="remove-item-from-esign-session")
+        view.index()
+        self.assertEqual(len(annot["sessions"]), 0)
+        self.assertEqual(len(annot["uids"]), 0)
+
+    def test_finished_shows_message_and_redirects(self):
+        """Test _finished sets a status message and redirects."""
+        view = getMultiAdapter((self.annexes[0], self.request), name="remove-item-from-esign-session")
+        view._finished()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertIn("removed from session", messages[0].message)
+        self.assertEqual(self.request.RESPONSE.getHeader("location"), self.annexes[0].absolute_url())

--- a/src/imio/esign/tests/test_browser_views.py
+++ b/src/imio/esign/tests/test_browser_views.py
@@ -4,9 +4,6 @@ from datetime import datetime
 from datetime import timedelta
 from imio.esign.browser.views import DownloadFileView
 from imio.esign.testing import IMIO_ESIGN_FUNCTIONAL_TESTING
-from imio.esign.testing import IMIO_ESIGN_INTEGRATION_TESTING
-from imio.esign.utils import add_files_to_session
-from imio.esign.utils import get_session_annotation
 from imio.pyutils.utils import shortuid_encode_id
 from plone import api
 from plone.app.testing import logout
@@ -15,8 +12,6 @@ from plone.app.testing import TEST_USER_ID
 from plone.namedfile.file import NamedBlobFile
 from plone.namedfile.file import NamedBlobImage
 from plone.testing import z2
-from Products.statusmessages.interfaces import IStatusMessage
-from zope.component import getMultiAdapter
 
 import collective.iconifiedcategory
 import os
@@ -163,108 +158,3 @@ class TestDownloadFileView(unittest.TestCase):
         browser.open("{}/download-file/{}".format(portal_url, "aabbccddee?param=value"))
         self.assertIn("The corresponding file identifier cannot be retrieved (aabbccddee)", browser.contents)
 
-
-class TestRemoveItemFromSessionView(unittest.TestCase):
-    """Test RemoveItemFromSessionView browser view."""
-
-    layer = IMIO_ESIGN_INTEGRATION_TESTING
-
-    def setUp(self):
-        self.portal = self.layer["portal"]
-        self.request = self.portal.REQUEST
-        setRoles(self.portal, TEST_USER_ID, ["Manager"])
-        # add content category configuration
-        at_folder = api.content.create(
-            container=self.portal,
-            id="annexes_types",
-            title="Annexes Types",
-            type="ContentCategoryConfiguration",
-            exclude_from_nav=True,
-        )
-        category_group = api.content.create(
-            type="ContentCategoryGroup",
-            title="Annexes",
-            container=at_folder,
-            id="annexes",
-        )
-        icon_path = os.path.join(os.path.dirname(collective.iconifiedcategory.__file__), "tests", "icône1.png")
-        with open(icon_path, "rb") as fl:
-            api.content.create(
-                type="ContentCategory",
-                title="To sign",
-                container=category_group,
-                icon=NamedBlobImage(fl.read(), filename=u"icône1.png"),
-                id="to_sign",
-                predefined_title="To be signed",
-                to_sign=True,
-                show_preview=False,
-            )
-        # add users and annexes
-        api.user.create(email="user1@sign.com", username="user1", password="password1")
-        self.folder = api.content.create(
-            container=self.portal, type="Folder", id="test_folder", title="Test Folder"
-        )
-        tests_dir = os.path.dirname(__file__)
-        self.annexes = []
-        for i in range(3):
-            with open(os.path.join(tests_dir, "annex1.pdf"), "rb") as f:
-                annex = api.content.create(
-                    container=self.folder,
-                    type="annex",
-                    id="annex{}".format(i),
-                    title="Annex {}".format(i),
-                    content_category="to_sign",
-                    scan_id="0123456000000{:02d}".format(i),
-                    file=NamedBlobFile(data=f.read(), filename=u"annex{}.pdf".format(i), contentType="application/pdf"),
-                )
-                self.annexes.append(annex)
-        self.signers = [("user1", "user1@sign.com", "User 1", "Position 1")]
-
-    def test_available(self):
-        """Test available method returns True."""
-        view = getMultiAdapter((self.annexes[0], self.request), name="remove-item-from-esign-session")
-        self.assertTrue(view.available())
-
-    def test_index_removes_file_from_session(self):
-        """Test index() removes the file from the esign session."""
-        annot = get_session_annotation()
-        # Add files to a session
-        uids = [a.UID() for a in self.annexes]
-        add_files_to_session(self.signers, uids)
-        self.assertEqual(len(annot["sessions"]), 1)
-        self.assertEqual(len(annot["uids"]), 3)
-        session = annot["sessions"][0]
-        self.assertEqual(len(session["files"]), 3)
-
-        # Remove one file via the view
-        view = getMultiAdapter((self.annexes[0], self.request), name="remove-item-from-esign-session")
-        view.index()
-        # The file should be removed from the session
-        self.assertNotIn(uids[0], annot["uids"])
-        self.assertEqual(len(annot["uids"]), 2)
-        self.assertEqual(len(session["files"]), 2)
-        remaining_uids = [f["uid"] for f in session["files"]]
-        self.assertNotIn(uids[0], remaining_uids)
-        self.assertIn(uids[1], remaining_uids)
-        self.assertIn(uids[2], remaining_uids)
-
-    def test_index_removes_last_file_removes_session(self):
-        """Test removing the last file from a session also removes the session."""
-        annot = get_session_annotation()
-        uids = [self.annexes[0].UID()]
-        add_files_to_session(self.signers, uids)
-        self.assertEqual(len(annot["sessions"]), 1)
-
-        view = getMultiAdapter((self.annexes[0], self.request), name="remove-item-from-esign-session")
-        view.index()
-        self.assertEqual(len(annot["sessions"]), 0)
-        self.assertEqual(len(annot["uids"]), 0)
-
-    def test_finished_shows_message_and_redirects(self):
-        """Test _finished sets a status message and redirects."""
-        view = getMultiAdapter((self.annexes[0], self.request), name="remove-item-from-esign-session")
-        view._finished()
-        messages = IStatusMessage(self.request).show()
-        self.assertEqual(len(messages), 1)
-        self.assertIn("removed from session", messages[0].message)
-        self.assertEqual(self.request.RESPONSE.getHeader("location"), self.annexes[0].absolute_url())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a "Remove item from esign session" action letting users remove a single item, see a success message, and return to the item's page.

* **Tests**
  * Add integration tests covering availability, single-item removal, session payload updates, full-session cleanup, and success redirect/message.

* **Chores**
  * Remove unused imports and apply minor test formatting cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->