### PR TITLE
admin views may raise unauthorized

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ setup(
     ],
     extras_require={
         "test": [
-            "mock",
             "plone.app.testing",
             # Plone KGS does not use this version, because it would break
             # Remove if your package shall be part of coredev.

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
             "plone.testing>=5.0.0",
             "plone.app.contenttypes",
             "plone.app.robotframework[debug]",
+            "mock",
             "imio.annex",
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
     ],
     extras_require={
         "test": [
+            "mock",
             "plone.app.testing",
             # Plone KGS does not use this version, because it would break
             # Remove if your package shall be part of coredev.

--- a/src/imio/esign/browser/views.py
+++ b/src/imio/esign/browser/views.py
@@ -114,9 +114,7 @@ class SessionDeleteView(BrowserView):
 
     def __call__(self):
         if not self.may_delete_session():
-            api.portal.show_message(_("You don't have permission to delete sessions!"), request=self.request,
-                                    type="error")
-            return self.request.RESPONSE.redirect(self.context.absolute_url())
+            raise Unauthorized
         session_id = self.request.get("esign_session_id")
         if not session_id:
             api.portal.show_message(_("No session ID provided!"), request=self.request, type="error")
@@ -142,9 +140,7 @@ class ExternalSessionCreateView(BrowserView):
 
     def __call__(self, session_id=None):
         if not self.may_create_external_sessions():
-            api.portal.show_message(_("You don't have permission to create external sessions!"), request=self.request,
-                                    type="error")
-            return self.context.absolute_url() + "/@@parapheo"
+            raise Unauthorized
         if session_id is None:
             session_id = self.request.get("session_id", None)
         if session_id is None:

--- a/src/imio/esign/browser/views.py
+++ b/src/imio/esign/browser/views.py
@@ -159,6 +159,12 @@ class ExternalSessionCreateView(BrowserView):
                 request=self.request,
                 type="error",
             )
+        elif resp == "_no_seal_email_":
+            api.portal.show_message(
+                _("No seal email defined in configuration ! Session ${id} not sent.", mapping={"id": session_id}),
+                request=self.request,
+                type="error",
+            )
         elif resp.status_code == 200:
             api.portal.show_message(_("External session sent successfully!"), request=self.request, type="info")
         else:

--- a/src/imio/esign/locales/en/LC_MESSAGES/imio.esign.po
+++ b/src/imio/esign/locales/en/LC_MESSAGES/imio.esign.po
@@ -441,14 +441,6 @@ msgstr ""
 msgid "You are about to send emails to"
 msgstr ""
 
-#: ../browser/views.py:146
-msgid "You don't have permission to create external sessions!"
-msgstr ""
-
-#: ../browser/views.py:118
-msgid "You don't have permission to delete sessions!"
-msgstr ""
-
 #: ../browser/views.py:589
 msgid "You have been invited to Paraphéo"
 msgstr ""

--- a/src/imio/esign/locales/en/LC_MESSAGES/imio.esign.po
+++ b/src/imio/esign/locales/en/LC_MESSAGES/imio.esign.po
@@ -182,6 +182,10 @@ msgstr ""
 msgid "No seal code defined in configuration ! Session ${id} not sent."
 msgstr ""
 
+#: ../browser/views.py:168
+msgid "No seal email defined in configuration ! Session ${id} not sent."
+msgstr ""
+
 #: ../browser/views.py:123
 msgid "No session ID provided!"
 msgstr ""

--- a/src/imio/esign/locales/fr/LC_MESSAGES/imio.esign.po
+++ b/src/imio/esign/locales/fr/LC_MESSAGES/imio.esign.po
@@ -183,6 +183,10 @@ msgstr "Aucun fichier"
 msgid "No seal code defined in configuration ! Session ${id} not sent."
 msgstr "Aucun code de sceau défini dans la configuration ! La session ${id} n'a pas été envoyée."
 
+#: ../browser/views.py:168
+msgid "No seal email defined in configuration ! Session ${id} not sent."
+msgstr "Aucun email de sceau défini dans la configuration ! La session ${id} n'a pas été envoyée."
+
 #: ../browser/views.py:123
 msgid "No session ID provided!"
 msgstr "Aucun identifiant de session fourni !"

--- a/src/imio/esign/locales/fr/LC_MESSAGES/imio.esign.po
+++ b/src/imio/esign/locales/fr/LC_MESSAGES/imio.esign.po
@@ -442,14 +442,6 @@ msgstr "Oui"
 msgid "You are about to send emails to"
 msgstr "Vous êtes sur le point d'envoyer des emails à"
 
-#: ../browser/views.py:146
-msgid "You don't have permission to create external sessions!"
-msgstr "Vous n'avez pas la permission de créer une session externe !"
-
-#: ../browser/views.py:118
-msgid "You don't have permission to delete sessions!"
-msgstr "Vous n'avez pas la permission de supprimer une session !"
-
 #: ../browser/views.py:589
 msgid "You have been invited to Paraphéo"
 msgstr "Vous êtes invité à activer votre compte sur Paraphéo"

--- a/src/imio/esign/locales/imio.esign.pot
+++ b/src/imio/esign/locales/imio.esign.pot
@@ -441,14 +441,6 @@ msgstr ""
 msgid "You are about to send emails to"
 msgstr ""
 
-#: ../browser/views.py:146
-msgid "You don't have permission to create external sessions!"
-msgstr ""
-
-#: ../browser/views.py:118
-msgid "You don't have permission to delete sessions!"
-msgstr ""
-
 #: ../browser/views.py:589
 msgid "You have been invited to Paraphéo"
 msgstr ""

--- a/src/imio/esign/locales/imio.esign.pot
+++ b/src/imio/esign/locales/imio.esign.pot
@@ -182,6 +182,10 @@ msgstr ""
 msgid "No seal code defined in configuration ! Session ${id} not sent."
 msgstr ""
 
+#: ../browser/views.py:168
+msgid "No seal email defined in configuration ! Session ${id} not sent."
+msgstr ""
+
 #: ../browser/views.py:123
 msgid "No session ID provided!"
 msgstr ""

--- a/src/imio/esign/tests/test_browser_views.py
+++ b/src/imio/esign/tests/test_browser_views.py
@@ -1,10 +1,19 @@
 # -*- coding: utf-8 -*-
 """Browser views tests for this package."""
+from AccessControl import Unauthorized
+from collective.iconifiedcategory.utils import calculate_category_id
 from datetime import datetime
 from datetime import timedelta
 from imio.esign.browser.views import DownloadFileView
+from imio.esign.browser.views import ExternalSessionCreateView
+from imio.esign.browser.views import SessionDeleteView
 from imio.esign.testing import IMIO_ESIGN_FUNCTIONAL_TESTING
+from imio.esign.testing import IMIO_ESIGN_INTEGRATION_TESTING
+from imio.esign.utils import add_files_to_session
+from imio.esign.utils import get_session_annotation
 from imio.pyutils.utils import shortuid_encode_id
+from mock import Mock
+from mock import patch
 from plone import api
 from plone.app.testing import logout
 from plone.app.testing import setRoles
@@ -12,11 +21,224 @@ from plone.app.testing import TEST_USER_ID
 from plone.namedfile.file import NamedBlobFile
 from plone.namedfile.file import NamedBlobImage
 from plone.testing import z2
+from Products.statusmessages.interfaces import IStatusMessage
 
 import collective.iconifiedcategory
 import os
 import transaction
 import unittest
+
+
+class _BaseSessionViewTest(unittest.TestCase):
+    """Base test class with shared setUp for session view tests."""
+
+    layer = IMIO_ESIGN_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+        # Create user for signing
+        api.user.create(email="user1@sign.com", username="user1", password="password1")
+
+        # Create content category configuration
+        at_folder = api.content.create(
+            container=self.portal,
+            id="annexes_types",
+            title="Annexes Types",
+            type="ContentCategoryConfiguration",
+            exclude_from_nav=True,
+        )
+        category_group = api.content.create(
+            type="ContentCategoryGroup",
+            title="Annexes",
+            container=at_folder,
+            id="annexes",
+        )
+        icon_path = os.path.join(
+            os.path.dirname(collective.iconifiedcategory.__file__), "tests", "icône1.png"
+        )
+        with open(icon_path, "rb") as fl:
+            api.content.create(
+                type="ContentCategory",
+                title="To sign",
+                container=category_group,
+                icon=NamedBlobImage(fl.read(), filename=u"icône1.png"),
+                id="to_sign",
+                predefined_title="To be signed",
+                to_sign=True,
+                show_preview=False,
+            )
+
+        # Create folder and annex
+        self.folder = api.content.create(
+            container=self.portal,
+            type="Folder",
+            id="test_folder",
+            title="Test Folder",
+        )
+        tests_dir = os.path.dirname(__file__)
+        with open(os.path.join(tests_dir, "annex1.pdf"), "rb") as f:
+            annex = api.content.create(
+                container=self.folder,
+                type="annex",
+                id="test_annex",
+                title="Test Annex",
+                content_category=calculate_category_id(
+                    self.portal["annexes_types"]["annexes"]["to_sign"]
+                ),
+                scan_id="012345600000001",
+                file=NamedBlobFile(
+                    data=f.read(),
+                    filename=u"annex1.pdf",
+                    contentType="application/pdf",
+                ),
+            )
+        self.annex_uid = annex.UID()
+
+        # Seed a session in the annotation
+        signers = [("user1", "user1@sign.com", "User 1", "Position 1")]
+        self.session_id, _ = add_files_to_session(signers, (self.annex_uid,))
+
+
+class TestSessionDeleteView(_BaseSessionViewTest):
+    """Test SessionDeleteView browser view."""
+
+    def test_may_delete_session(self):
+        """Manager role grants may_delete_session."""
+        view = SessionDeleteView(self.folder, self.request)
+        self.assertTrue(view.may_delete_session())
+
+    def test_may_delete_session_no_permission(self):
+        """Member-only role denies may_delete_session."""
+        setRoles(self.portal, TEST_USER_ID, ["Member"])
+        view = SessionDeleteView(self.folder, self.request)
+        self.assertFalse(view.may_delete_session())
+        with self.assertRaises(Unauthorized):
+            view()
+
+    def test_call_no_session_id(self):
+        """Missing esign_session_id produces an error message and redirects to context URL."""
+        view = SessionDeleteView(self.folder, self.request)
+        view()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertIn("No session ID provided!", messages[0].message)
+        self.assertEqual(messages[0].type, "error")
+        location = self.request.RESPONSE.getHeader("location")
+        self.assertEqual(location, self.folder.absolute_url())
+
+    def test_call_session_exists(self):
+        """Valid esign_session_id removes the session and shows a success message."""
+        self.request.form["esign_session_id"] = str(self.session_id)
+        view = SessionDeleteView(self.folder, self.request)
+        view()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertIn("Session deleted successfully!", messages[0].message)
+        self.assertEqual(messages[0].type, "info")
+        location = self.request.RESPONSE.getHeader("location")
+        self.assertIn("@@parapheo", location)
+        annotation = get_session_annotation()
+        self.assertNotIn(self.session_id, annotation["sessions"])
+
+    def test_call_session_not_found(self):
+        """Non-existent esign_session_id shows an error and redirects to @@parapheo."""
+        self.request.form["esign_session_id"] = "9999"
+        view = SessionDeleteView(self.folder, self.request)
+        view()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertIn("Session not found!", messages[0].message)
+        self.assertEqual(messages[0].type, "error")
+        location = self.request.RESPONSE.getHeader("location")
+        self.assertIn("@@parapheo", location)
+
+
+class TestExternalSessionCreateView(_BaseSessionViewTest):
+    """Test ExternalSessionCreateView browser view."""
+
+    def test_may_create_external_sessions(self):
+        """Manager role grants may_create_external_sessions."""
+        view = ExternalSessionCreateView(self.folder, self.request)
+        self.assertTrue(view.may_create_external_sessions())
+
+    def test_call_unauthorized(self):
+        """Calling view without permission raises Unauthorized."""
+        setRoles(self.portal, TEST_USER_ID, ["Member"])
+        view = ExternalSessionCreateView(self.folder, self.request)
+        self.assertFalse(view.may_create_external_sessions())
+        with self.assertRaises(Unauthorized):
+            view()
+
+    def test_call_no_session_id(self):
+        """Missing session_id produces an error message and returns URL with @@parapheo."""
+        view = ExternalSessionCreateView(self.folder, self.request)
+        result = view()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertIn("No session ID provided!", messages[0].message)
+        self.assertEqual(messages[0].type, "error")
+        self.assertIn("@@parapheo", result)
+
+    def test_call_session_not_found(self):
+        """create_external_session returning _session_not_found_ shows an error."""
+        self.request.form["session_id"] = str(self.session_id)
+        view = ExternalSessionCreateView(self.folder, self.request)
+        with patch("imio.esign.browser.views.create_external_session") as mock_create:
+            mock_create.return_value = "_session_not_found_"
+            result = view()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertIn("doesn't exist anymore", messages[0].message)
+        self.assertEqual(messages[0].type, "error")
+        self.assertIn("@@parapheo", result)
+
+    def test_call_no_seal_code(self):
+        """create_external_session returning _no_seal_code_ shows an error."""
+        self.request.form["session_id"] = str(self.session_id)
+        view = ExternalSessionCreateView(self.folder, self.request)
+        with patch("imio.esign.browser.views.create_external_session") as mock_create:
+            mock_create.return_value = "_no_seal_code_"
+            result = view()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertIn("No seal code", messages[0].message)
+        self.assertEqual(messages[0].type, "error")
+        self.assertIn("@@parapheo", result)
+
+    def test_call_success(self):
+        """create_external_session returning a 200 response shows a success message."""
+        self.request.form["session_id"] = str(self.session_id)
+        view = ExternalSessionCreateView(self.folder, self.request)
+        mock_response = Mock()
+        mock_response.status_code = 200
+        with patch("imio.esign.browser.views.create_external_session") as mock_create:
+            mock_create.return_value = mock_response
+            result = view()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertIn("External session sent successfully!", messages[0].message)
+        self.assertEqual(messages[0].type, "info")
+        self.assertIn("@@parapheo", result)
+
+    def test_call_error_response(self):
+        """create_external_session returning a non-200 response shows the status details."""
+        self.request.form["session_id"] = str(self.session_id)
+        view = ExternalSessionCreateView(self.folder, self.request)
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.reason = "Server Error"
+        mock_response.text = "oops"
+        with patch("imio.esign.browser.views.create_external_session") as mock_create:
+            mock_create.return_value = mock_response
+            result = view()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertIn("500", messages[0].message)
+        self.assertEqual(messages[0].type, "error")
+        self.assertIn("@@parapheo", result)
 
 
 @unittest.skip("Test skipped")
@@ -157,4 +379,3 @@ class TestDownloadFileView(unittest.TestCase):
         self.assertIn("The corresponding file identifier cannot be retrieved (aabbccddee)", browser.contents)
         browser.open("{}/download-file/{}".format(portal_url, "aabbccddee?param=value"))
         self.assertIn("The corresponding file identifier cannot be retrieved (aabbccddee)", browser.contents)
-

--- a/src/imio/esign/tests/test_browser_views.py
+++ b/src/imio/esign/tests/test_browser_views.py
@@ -208,6 +208,19 @@ class TestExternalSessionCreateView(_BaseSessionViewTest):
         self.assertEqual(messages[0].type, "error")
         self.assertIn("@@parapheo", result)
 
+    def test_call_no_seal_email(self):
+        """create_external_session returning _no_seal_email_ shows an error."""
+        self.request.form["session_id"] = str(self.session_id)
+        view = ExternalSessionCreateView(self.folder, self.request)
+        with patch("imio.esign.browser.views.create_external_session") as mock_create:
+            mock_create.return_value = "_no_seal_email_"
+            result = view()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertIn("No seal email", messages[0].message)
+        self.assertEqual(messages[0].type, "error")
+        self.assertIn("@@parapheo", result)
+
     def test_call_success(self):
         """create_external_session returning a 200 response shows a success message."""
         self.request.form["session_id"] = str(self.session_id)

--- a/src/imio/esign/tests/test_browser_views.py
+++ b/src/imio/esign/tests/test_browser_views.py
@@ -37,6 +37,7 @@ class _BaseSessionViewTest(unittest.TestCase):
     def setUp(self):
         self.portal = self.layer["portal"]
         self.request = self.layer["request"]
+        self.request.form.clear()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
         # Create user for signing

--- a/src/imio/esign/tests/test_browser_views.py
+++ b/src/imio/esign/tests/test_browser_views.py
@@ -40,7 +40,7 @@ class _BaseSessionViewTest(unittest.TestCase):
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
         # Create user for signing
-        api.user.create(email="user1@sign.com", username="user1", password="password1")
+        api.user.create(email="user1@sign.com", username="user1", password="password1")  # noqa: S106
 
         # Create content category configuration
         at_folder = api.content.create(

--- a/src/imio/esign/tests/test_utils.py
+++ b/src/imio/esign/tests/test_utils.py
@@ -317,6 +317,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(session2["state"], "draft")
 
         # Case 4: seal session without seal_code configured => returns "_no_seal_code_", no HTTP call
+        api.portal.set_registry_record("imio.esign.seal_email", u"seal@example.com")
         annex0_obj = uuidToObject(uuid=self.uids[0], unrestricted=True)
         annex0_obj.file.filename = u"annex1.pdf"
         sid3, session3 = add_files_to_session(signers, (self.uids[4], self.uids[1], self.uids[0]), seal="PADES_SEAL")

--- a/src/imio/esign/tests/test_utils.py
+++ b/src/imio/esign/tests/test_utils.py
@@ -7,16 +7,20 @@ from imio.esign.config import get_registry_max_session_size
 from imio.esign.config import set_registry_max_session_size
 from imio.esign.testing import IMIO_ESIGN_INTEGRATION_TESTING
 from imio.esign.utils import add_files_to_session
+from imio.esign.utils import create_external_session
 from imio.esign.utils import get_file_download_url
 from imio.esign.utils import get_filesize
 from imio.esign.utils import get_max_download_date
 from imio.esign.utils import get_session_annotation
 from imio.esign.utils import get_session_info
+from imio.esign.utils import get_suid_from_uuid
 from imio.esign.utils import remove_context_from_session
 from imio.esign.utils import remove_files_from_session
 from imio.esign.utils import remove_session
 from imio.helpers.content import uuidToObject
 from imio.pyutils.utils import shortuid_decode_id
+from mock import Mock
+from mock import patch
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -25,6 +29,7 @@ from plone.namedfile.file import NamedBlobImage
 from zope.annotation import IAnnotations
 
 import collective.iconifiedcategory
+import json
 import os
 import unittest
 
@@ -407,6 +412,153 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(get_max_download_date(annex, timedelta(days=0)), mod_date)
         today = date.today()
         self.assertEqual(get_max_download_date(None, timedelta(days=0), today), today)
+
+    def test_create_external_session_not_found(self):
+        """Returns _session_not_found_ for a non-existent session id."""
+        result = create_external_session(9999)
+        self.assertEqual(result, "_session_not_found_")
+
+    def test_create_external_session_no_seal_email(self):
+        """Returns _no_seal_email_ when session requires a seal but no email configured."""
+        sid, _session = add_files_to_session([], (self.uids[0],), seal="SEAL")
+        # seal_email defaults to "" (falsy) — no registry setup needed
+        result = create_external_session(sid, esign_root_url="http://test.example.com")
+        self.assertEqual(result, "_no_seal_email_")
+
+    def test_create_external_session_no_seal_code(self):
+        """Returns _no_seal_code_ when seal email is set but seal code is missing."""
+        sid, _session = add_files_to_session([], (self.uids[0],), seal="SEAL")
+        api.portal.set_registry_record("imio.esign.seal_email", u"seal@example.com")
+        self.addCleanup(api.portal.set_registry_record, "imio.esign.seal_email", u"")
+        # seal_code defaults to "" (falsy)
+        result = create_external_session(sid, esign_root_url="http://test.example.com")
+        self.assertEqual(result, "_no_seal_code_")
+
+    def test_create_external_session_error_response(self):
+        """Returns response object and leaves session state unchanged on non-200."""
+        signers = [("user1", "user1@sign.com", "User 1", "Position 1")]
+        sid, session = add_files_to_session(signers, (self.uids[0],))
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        with patch("imio.esign.utils.requests.post", return_value=mock_response):
+            with patch("imio.esign.utils.get_auth_token", return_value="test-token"):
+                result = create_external_session(sid, esign_root_url="http://test.example.com")
+        self.assertIs(result, mock_response)
+        self.assertEqual(session["state"], "draft")
+
+    def test_create_external_session_sign_payload(self):
+        """Returns response object, sets session state to 'sent', and signData contains signer email."""
+        signers = [("user1", "user1@sign.com", "User 1", "Position 1")]
+        sid, session = add_files_to_session(signers, (self.uids[0],))
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = '{"message": "OK"}'
+        with patch("imio.esign.utils.requests.post", return_value=mock_response) as mock_post:
+            with patch("imio.esign.utils.get_auth_token", return_value="test-token"):
+                result = create_external_session(sid, esign_root_url="http://test.example.com")
+        self.assertIs(result, mock_response)
+        self.assertEqual(session["state"], "sent")
+        payload = json.loads(mock_post.call_args[1]["data"]["data"])
+        self.assertEqual(
+            payload,
+            {
+                u"commonData": {
+                    u"imioAppSessionId": u"012345600000",
+                    u"vatNumber": None,
+                    u"endpointUrl": u"http://nohost/plone/@external_session_feedback",
+                    u"sessionName": u"Session 0",
+                    u"documentData": [
+                        {
+                            u"uniqueCode": u"012345600000000__{}".format(self.uids[0]),
+                            u"docUuid": get_suid_from_uuid(self.uids[0]),
+                            u"filename": u"annex0.pdf",
+                        }
+                    ],
+                },
+                u"signData": {u"acroform": True, u"users": [u"user1@sign.com"]},
+            },
+        )
+
+    def test_create_external_session_seal_payload(self):
+        """Seal-only session: sealData contains seal email and code; no signData."""
+        sid, _session = add_files_to_session([], (self.uids[0],), seal="SEAL")
+        api.portal.set_registry_record("imio.esign.seal_email", u"seal@example.com")
+        api.portal.set_registry_record("imio.esign.seal_code", u"PADES_SEAL")
+        self.addCleanup(api.portal.set_registry_record, "imio.esign.seal_email", u"")
+        self.addCleanup(api.portal.set_registry_record, "imio.esign.seal_code", u"")
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = '{"message": "OK"}'
+        with patch("imio.esign.utils.requests.post", return_value=mock_response) as mock_post:
+            with patch("imio.esign.utils.get_auth_token", return_value="test-token"):
+                create_external_session(sid, esign_root_url="http://test.example.com")
+        payload = json.loads(mock_post.call_args[1]["data"]["data"])
+        self.assertEqual(
+            payload,
+            {
+                u"commonData": {
+                    u"imioAppSessionId": u"012345600000",
+                    u"vatNumber": None,
+                    u"endpointUrl": u"http://nohost/plone/@external_session_feedback",
+                    u"sessionName": u"Session 0",
+                    u"documentData": [
+                        {
+                            u"uniqueCode": u"012345600000000__{}".format(self.uids[0]),
+                            u"docUuid": get_suid_from_uuid(self.uids[0]),
+                            u"filename": u"annex0.pdf",
+                        }
+                    ],
+                },
+                u"sealData": {
+                    u"sealCode": u"PADES_SEAL",
+                    u"acroform": True,
+                    u"users": [u"seal@example.com"],
+                    u"watchers": [],
+                },
+            },
+        )
+
+    def test_create_external_session_both_payload(self):
+        """Session with signers and seal: both signData and sealData are present."""
+        signers = [("user1", "user1@sign.com", "User 1", "Position 1")]
+        sid, _session = add_files_to_session(signers, (self.uids[0],), seal="SEAL")
+        api.portal.set_registry_record("imio.esign.seal_email", u"seal@example.com")
+        api.portal.set_registry_record("imio.esign.seal_code", u"PADES_SEAL")
+        self.addCleanup(api.portal.set_registry_record, "imio.esign.seal_email", u"")
+        self.addCleanup(api.portal.set_registry_record, "imio.esign.seal_code", u"")
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = '{"message": "OK"}'
+        with patch("imio.esign.utils.requests.post", return_value=mock_response) as mock_post:
+            with patch("imio.esign.utils.get_auth_token", return_value="test-token"):
+                create_external_session(sid, esign_root_url="http://test.example.com")
+        payload = json.loads(mock_post.call_args[1]["data"]["data"])
+        self.assertEqual(
+            payload,
+            {
+                u"signData": {u"acroform": True, u"users": [u"user1@sign.com"]},
+                u"commonData": {
+                    u"imioAppSessionId": u"012345600000",
+                    u"vatNumber": None,
+                    u"endpointUrl": u"http://nohost/plone/@external_session_feedback",
+                    u"sessionName": u"Session 0",
+                    u"documentData": [
+                        {
+                            u"uniqueCode": u"012345600000000__{}".format(self.uids[0]),
+                            u"docUuid": get_suid_from_uuid(self.uids[0]),
+                            u"filename": u"annex0.pdf",
+                        }
+                    ],
+                },
+                u"sealData": {
+                    u"sealCode": u"PADES_SEAL",
+                    u"acroform": True,
+                    u"users": [u"seal@example.com"],
+                    u"watchers": [],
+                },
+            },
+        )
 
 
 # example of annotation content

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -156,6 +156,9 @@ def create_external_session(session_id, esign_root_url=None):
 
     if session["seal"]:
         seal_email = get_registry_seal_email()
+        if not seal_email:
+            logger.error("No seal email configured in registry.")
+            return "_no_seal_email_"
         seal_code = get_registry_seal_code()  # PADES_SEAL
         if not seal_code:
             logger.error("No seal code configured in registry.")

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -22,7 +22,6 @@ from persistent.mapping import PersistentMapping
 from plone import api
 from zope.annotation import IAnnotations
 from zope.component import getAdapter
-from zope.i18n import translate
 
 import json
 import requests

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -173,9 +173,9 @@ def create_external_session(session_id, esign_root_url=None):
             logger.error("No seal code configured in registry.")
             return "_no_seal_code_"
         data_payload["sealData"] = {
-            "users": seal_email and [seal_email] or [],
+            "users": [seal_email],
             # "placeholderName": "SCEAU",  # default
-            "acroform": bool(seal_email),  # default False
+            "acroform": True,
             "watchers": list(session.get("watchers", [])),
             "sealCode": seal_code,
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization failures for session create/delete now produce consistent error responses instead of user notifications.

* **New Behavior**
  * When a session requires a seal but no seal email is configured, users now see a clear error indicating the missing seal email.

* **Tests**
  * Added integration and unit tests covering session create/delete flows, permission checks, missing parameters, and seal-related error handling.

* **Localization**
  * Removed two unused permission messages; added translation for the missing-seal-email error.

* **Chores**
  * Test dependencies updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->