### PR TITLE
Added _no_seal_email_ error + tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
             "plone.testing>=5.0.0",
             "plone.app.contenttypes",
             "plone.app.robotframework[debug]",
+            "mock",
             "imio.annex",
         ],
     },

--- a/src/imio/esign/browser/views.py
+++ b/src/imio/esign/browser/views.py
@@ -159,6 +159,12 @@ class ExternalSessionCreateView(BrowserView):
                 request=self.request,
                 type="error",
             )
+        elif resp == "_no_seal_email_":
+            api.portal.show_message(
+                _("No seal email defined in configuration ! Session ${id} not sent.", mapping={"id": session_id}),
+                request=self.request,
+                type="error",
+            )
         elif resp.status_code == 200:
             api.portal.show_message(_("External session sent successfully!"), request=self.request, type="info")
         else:

--- a/src/imio/esign/locales/en/LC_MESSAGES/imio.esign.po
+++ b/src/imio/esign/locales/en/LC_MESSAGES/imio.esign.po
@@ -182,6 +182,10 @@ msgstr ""
 msgid "No seal code defined in configuration ! Session ${id} not sent."
 msgstr ""
 
+#: ../browser/views.py:168
+msgid "No seal email defined in configuration ! Session ${id} not sent."
+msgstr ""
+
 #: ../browser/views.py:123
 msgid "No session ID provided!"
 msgstr ""

--- a/src/imio/esign/locales/fr/LC_MESSAGES/imio.esign.po
+++ b/src/imio/esign/locales/fr/LC_MESSAGES/imio.esign.po
@@ -183,6 +183,10 @@ msgstr "Aucun fichier"
 msgid "No seal code defined in configuration ! Session ${id} not sent."
 msgstr "Aucun code de sceau défini dans la configuration ! La session ${id} n'a pas été envoyée."
 
+#: ../browser/views.py:168
+msgid "No seal email defined in configuration ! Session ${id} not sent."
+msgstr "Aucun email de sceau défini dans la configuration ! La session ${id} n'a pas été envoyée."
+
 #: ../browser/views.py:123
 msgid "No session ID provided!"
 msgstr "Aucun identifiant de session fourni !"

--- a/src/imio/esign/locales/imio.esign.pot
+++ b/src/imio/esign/locales/imio.esign.pot
@@ -182,6 +182,10 @@ msgstr ""
 msgid "No seal code defined in configuration ! Session ${id} not sent."
 msgstr ""
 
+#: ../browser/views.py:168
+msgid "No seal email defined in configuration ! Session ${id} not sent."
+msgstr ""
+
 #: ../browser/views.py:123
 msgid "No session ID provided!"
 msgstr ""

--- a/src/imio/esign/tests/test_browser_views.py
+++ b/src/imio/esign/tests/test_browser_views.py
@@ -208,6 +208,19 @@ class TestExternalSessionCreateView(_BaseSessionViewTest):
         self.assertEqual(messages[0].type, "error")
         self.assertIn("@@parapheo", result)
 
+    def test_call_no_seal_email(self):
+        """create_external_session returning _no_seal_email_ shows an error."""
+        self.request.form["session_id"] = str(self.session_id)
+        view = ExternalSessionCreateView(self.folder, self.request)
+        with patch("imio.esign.browser.views.create_external_session") as mock_create:
+            mock_create.return_value = "_no_seal_email_"
+            result = view()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertIn("No seal email", messages[0].message)
+        self.assertEqual(messages[0].type, "error")
+        self.assertIn("@@parapheo", result)
+
     def test_call_success(self):
         """create_external_session returning a 200 response shows a success message."""
         self.request.form["session_id"] = str(self.session_id)

--- a/src/imio/esign/tests/test_utils.py
+++ b/src/imio/esign/tests/test_utils.py
@@ -7,16 +7,20 @@ from imio.esign.config import get_registry_max_session_size
 from imio.esign.config import set_registry_max_session_size
 from imio.esign.testing import IMIO_ESIGN_INTEGRATION_TESTING
 from imio.esign.utils import add_files_to_session
+from imio.esign.utils import create_external_session
 from imio.esign.utils import get_file_download_url
 from imio.esign.utils import get_filesize
 from imio.esign.utils import get_max_download_date
 from imio.esign.utils import get_session_annotation
 from imio.esign.utils import get_session_info
+from imio.esign.utils import get_suid_from_uuid
 from imio.esign.utils import remove_context_from_session
 from imio.esign.utils import remove_files_from_session
 from imio.esign.utils import remove_session
 from imio.helpers.content import uuidToObject
 from imio.pyutils.utils import shortuid_decode_id
+from mock import Mock
+from mock import patch
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -25,6 +29,7 @@ from plone.namedfile.file import NamedBlobImage
 from zope.annotation import IAnnotations
 
 import collective.iconifiedcategory
+import json
 import os
 import unittest
 
@@ -407,6 +412,153 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(get_max_download_date(annex, timedelta(days=0)), mod_date)
         today = date.today()
         self.assertEqual(get_max_download_date(None, timedelta(days=0), today), today)
+
+    def test_create_external_session_not_found(self):
+        """Returns _session_not_found_ for a non-existent session id."""
+        result = create_external_session(9999)
+        self.assertEqual(result, "_session_not_found_")
+
+    def test_create_external_session_no_seal_email(self):
+        """Returns _no_seal_email_ when session requires a seal but no email configured."""
+        sid, _session = add_files_to_session([], (self.uids[0],), seal="SEAL")
+        # seal_email defaults to "" (falsy) — no registry setup needed
+        result = create_external_session(sid, esign_root_url="http://test.example.com")
+        self.assertEqual(result, "_no_seal_email_")
+
+    def test_create_external_session_no_seal_code(self):
+        """Returns _no_seal_code_ when seal email is set but seal code is missing."""
+        sid, _session = add_files_to_session([], (self.uids[0],), seal="SEAL")
+        api.portal.set_registry_record("imio.esign.seal_email", u"seal@example.com")
+        self.addCleanup(api.portal.set_registry_record, "imio.esign.seal_email", u"")
+        # seal_code defaults to "" (falsy)
+        result = create_external_session(sid, esign_root_url="http://test.example.com")
+        self.assertEqual(result, "_no_seal_code_")
+
+    def test_create_external_session_error_response(self):
+        """Returns response object and leaves session state unchanged on non-200."""
+        signers = [("user1", "user1@sign.com", "User 1", "Position 1")]
+        sid, session = add_files_to_session(signers, (self.uids[0],))
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        with patch("imio.esign.utils.requests.post", return_value=mock_response):
+            with patch("imio.esign.utils.get_auth_token", return_value="test-token"):
+                result = create_external_session(sid, esign_root_url="http://test.example.com")
+        self.assertIs(result, mock_response)
+        self.assertEqual(session["state"], "draft")
+
+    def test_create_external_session_sign_payload(self):
+        """Returns response object, sets session state to 'sent', and signData contains signer email."""
+        signers = [("user1", "user1@sign.com", "User 1", "Position 1")]
+        sid, session = add_files_to_session(signers, (self.uids[0],))
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = '{"message": "OK"}'
+        with patch("imio.esign.utils.requests.post", return_value=mock_response) as mock_post:
+            with patch("imio.esign.utils.get_auth_token", return_value="test-token"):
+                result = create_external_session(sid, esign_root_url="http://test.example.com")
+        self.assertIs(result, mock_response)
+        self.assertEqual(session["state"], "sent")
+        payload = json.loads(mock_post.call_args[1]["data"]["data"])
+        self.assertEqual(
+            payload,
+            {
+                u"commonData": {
+                    u"imioAppSessionId": u"012345600000",
+                    u"vatNumber": None,
+                    u"endpointUrl": u"http://nohost/plone/@external_session_feedback",
+                    u"sessionName": u"Session 0",
+                    u"documentData": [
+                        {
+                            u"uniqueCode": u"012345600000000__{}".format(self.uids[0]),
+                            u"docUuid": get_suid_from_uuid(self.uids[0]),
+                            u"filename": u"annex0.pdf",
+                        }
+                    ],
+                },
+                u"signData": {u"acroform": True, u"users": [u"user1@sign.com"]},
+            },
+        )
+
+    def test_create_external_session_seal_payload(self):
+        """Seal-only session: sealData contains seal email and code; no signData."""
+        sid, _session = add_files_to_session([], (self.uids[0],), seal="SEAL")
+        api.portal.set_registry_record("imio.esign.seal_email", u"seal@example.com")
+        api.portal.set_registry_record("imio.esign.seal_code", u"PADES_SEAL")
+        self.addCleanup(api.portal.set_registry_record, "imio.esign.seal_email", u"")
+        self.addCleanup(api.portal.set_registry_record, "imio.esign.seal_code", u"")
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = '{"message": "OK"}'
+        with patch("imio.esign.utils.requests.post", return_value=mock_response) as mock_post:
+            with patch("imio.esign.utils.get_auth_token", return_value="test-token"):
+                create_external_session(sid, esign_root_url="http://test.example.com")
+        payload = json.loads(mock_post.call_args[1]["data"]["data"])
+        self.assertEqual(
+            payload,
+            {
+                u"commonData": {
+                    u"imioAppSessionId": u"012345600000",
+                    u"vatNumber": None,
+                    u"endpointUrl": u"http://nohost/plone/@external_session_feedback",
+                    u"sessionName": u"Session 0",
+                    u"documentData": [
+                        {
+                            u"uniqueCode": u"012345600000000__{}".format(self.uids[0]),
+                            u"docUuid": get_suid_from_uuid(self.uids[0]),
+                            u"filename": u"annex0.pdf",
+                        }
+                    ],
+                },
+                u"sealData": {
+                    u"sealCode": u"PADES_SEAL",
+                    u"acroform": True,
+                    u"users": [u"seal@example.com"],
+                    u"watchers": [],
+                },
+            },
+        )
+
+    def test_create_external_session_both_payload(self):
+        """Session with signers and seal: both signData and sealData are present."""
+        signers = [("user1", "user1@sign.com", "User 1", "Position 1")]
+        sid, _session = add_files_to_session(signers, (self.uids[0],), seal="SEAL")
+        api.portal.set_registry_record("imio.esign.seal_email", u"seal@example.com")
+        api.portal.set_registry_record("imio.esign.seal_code", u"PADES_SEAL")
+        self.addCleanup(api.portal.set_registry_record, "imio.esign.seal_email", u"")
+        self.addCleanup(api.portal.set_registry_record, "imio.esign.seal_code", u"")
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = '{"message": "OK"}'
+        with patch("imio.esign.utils.requests.post", return_value=mock_response) as mock_post:
+            with patch("imio.esign.utils.get_auth_token", return_value="test-token"):
+                create_external_session(sid, esign_root_url="http://test.example.com")
+        payload = json.loads(mock_post.call_args[1]["data"]["data"])
+        self.assertEqual(
+            payload,
+            {
+                u"signData": {u"acroform": True, u"users": [u"user1@sign.com"]},
+                u"commonData": {
+                    u"imioAppSessionId": u"012345600000",
+                    u"vatNumber": None,
+                    u"endpointUrl": u"http://nohost/plone/@external_session_feedback",
+                    u"sessionName": u"Session 0",
+                    u"documentData": [
+                        {
+                            u"uniqueCode": u"012345600000000__{}".format(self.uids[0]),
+                            u"docUuid": get_suid_from_uuid(self.uids[0]),
+                            u"filename": u"annex0.pdf",
+                        }
+                    ],
+                },
+                u"sealData": {
+                    u"sealCode": u"PADES_SEAL",
+                    u"acroform": True,
+                    u"users": [u"seal@example.com"],
+                    u"watchers": [],
+                },
+            },
+        )
 
 
 # example of annotation content

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -156,6 +156,9 @@ def create_external_session(session_id, esign_root_url=None):
 
     if session["seal"]:
         seal_email = get_registry_seal_email()
+        if not seal_email:
+            logger.error("No seal email configured in registry.")
+            return "_no_seal_email_"
         seal_code = get_registry_seal_code()  # PADES_SEAL
         if not seal_code:
             logger.error("No seal code configured in registry.")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Sessions now display an error message when seal email configuration is missing, preventing silent failures.

* **Documentation**
  * Extended translations for configuration error messages in English and French.

* **Tests**
  * Expanded test coverage for session creation and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->