### PR TITLE
Included watchers in SigningUsersCsv

### DIFF
--- a/src/imio/esign/browser/views.py
+++ b/src/imio/esign/browser/views.py
@@ -420,12 +420,17 @@ class SigningUsersCsv(BrowserView):
             portal_type="held_position",
             userid=user_data["userid"],
         )
-        if not hps:
-            return False
         for hp in hps:
             hp_obj = hp.getObject()
             if base_hasattr(hp_obj, "usages") and "signer" in hp_obj.usages:
                 return True
+
+        user_obj = api.user.get(userid=user_data["userid"])
+        if user_obj:
+            for group in api.group.get_groups(user=user_obj):
+                if group.getId().endswith("watchers"):
+                    return True
+
         return False
 
     def get_users_data(self):
@@ -515,7 +520,7 @@ class SigningUsersCsv(BrowserView):
         # Parse JSON array
         try:
             return json.loads(selected)
-        except (json.JSONDecodeError, ValueError, TypeError):
+        except (ValueError, TypeError):
             return []
 
     def _download_csv(self):

--- a/src/imio/esign/tests/test_browser_views.py
+++ b/src/imio/esign/tests/test_browser_views.py
@@ -7,6 +7,8 @@ from datetime import timedelta
 from imio.esign.browser.views import DownloadFileView
 from imio.esign.browser.views import ExternalSessionCreateView
 from imio.esign.browser.views import SessionDeleteView
+from imio.esign.browser.views import SigningUsersCsv
+from imio.esign.config import set_registry_signing_users_email_content
 from imio.esign.testing import IMIO_ESIGN_FUNCTIONAL_TESTING
 from imio.esign.testing import IMIO_ESIGN_INTEGRATION_TESTING
 from imio.esign.utils import add_files_to_session
@@ -24,6 +26,7 @@ from plone.testing import z2
 from Products.statusmessages.interfaces import IStatusMessage
 
 import collective.iconifiedcategory
+import json
 import os
 import transaction
 import unittest
@@ -393,3 +396,280 @@ class TestDownloadFileView(unittest.TestCase):
         self.assertIn("The corresponding file identifier cannot be retrieved (aabbccddee)", browser.contents)
         browser.open("{}/download-file/{}".format(portal_url, "aabbccddee?param=value"))
         self.assertIn("The corresponding file identifier cannot be retrieved (aabbccddee)", browser.contents)
+
+
+class TestSigningUsersCsv(unittest.TestCase):
+    """Tests for the SigningUsersCsv view."""
+
+    layer = IMIO_ESIGN_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        self.request.form.clear()
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.user = api.user.create(email="signer@test.com", username="signer_user", password="password1")  # noqa: S106
+
+    def _make_user_data(self, user):
+        return {
+            "userid": user.getId(),
+            "email": user.getProperty("email", ""),
+            "lastname": "",
+            "firstname": "",
+            "fullname": user.getProperty("fullname", ""),
+        }
+
+    # --- filter_user ---
+
+    def test_filter_user_in_watchers_group_returns_true(self):
+        """User in a group ending with 'watchers' is included by default."""
+        api.group.create(groupname="myservice_watchers")
+        api.group.add_user(groupname="myservice_watchers", user=self.user)
+        view = SigningUsersCsv(self.portal, self.request)
+        self.assertTrue(view.filter_user(self._make_user_data(self.user)))
+
+    def test_filter_user_not_in_any_group_returns_false(self):
+        """User with no held_position and no watchers group is excluded."""
+        view = SigningUsersCsv(self.portal, self.request)
+        self.assertFalse(view.filter_user(self._make_user_data(self.user)))
+
+    def test_filter_user_in_non_watchers_group_returns_false(self):
+        """User in a group not ending with 'watchers' is excluded."""
+        api.group.create(groupname="myservice_editors")
+        api.group.add_user(groupname="myservice_editors", user=self.user)
+        view = SigningUsersCsv(self.portal, self.request)
+        self.assertFalse(view.filter_user(self._make_user_data(self.user)))
+
+    def test_filter_user_with_signer_held_position_returns_true(self):
+        """User with a held_position having 'signer' in usages is included by default."""
+        mock_hp_obj = Mock()
+        mock_hp_obj.usages = ["signer"]
+        mock_brain = Mock()
+        mock_brain.getObject.return_value = mock_hp_obj
+        view = SigningUsersCsv(self.portal, self.request)
+        with patch("imio.esign.browser.views.api.content.find", return_value=[mock_brain]):
+            result = view.filter_user(self._make_user_data(self.user))
+        self.assertTrue(result)
+
+    # --- get_users_data ---
+
+    def test_get_users_data(self):
+        """Returns data for all users with duplicates."""
+        view = SigningUsersCsv(self.portal, self.request)
+        users_data, _duplicates = view.get_users_data()
+        self.assertEqual(
+            users_data,
+            [
+                {
+                    "checked": False,
+                    "firstname": u"",
+                    "lastname": u"signer_user",
+                    "userid": "signer_user",
+                    "has_duplicate_email": False,
+                    "fullname": "",
+                    "email": "signer@test.com",
+                },
+                {
+                    "checked": False,
+                    "firstname": u"",
+                    "lastname": u"test_user_1_",
+                    "userid": "test_user_1_",
+                    "has_duplicate_email": False,
+                    "fullname": "",
+                    "email": "",
+                },
+            ],
+        )
+
+        # Test duplicates
+        api.user.create(email="signer@test.com", username="signer_user2", password="password1")  # noqa: S106
+        view = SigningUsersCsv(self.portal, self.request)
+        users_data, duplicates = view.get_users_data()
+        self.assertEqual(
+            users_data,
+            [
+                {
+                    "checked": False,
+                    "firstname": u"",
+                    "lastname": u"signer_user",
+                    "userid": "signer_user",
+                    "has_duplicate_email": True,
+                    "fullname": "",
+                    "email": "signer@test.com",
+                },
+                {
+                    "checked": False,
+                    "firstname": u"",
+                    "lastname": u"signer_user2",
+                    "userid": "signer_user2",
+                    "has_duplicate_email": True,
+                    "fullname": "",
+                    "email": "signer@test.com",
+                },
+                {
+                    "checked": False,
+                    "firstname": u"",
+                    "lastname": u"test_user_1_",
+                    "userid": "test_user_1_",
+                    "has_duplicate_email": False,
+                    "fullname": "",
+                    "email": "",
+                },
+            ],
+        )
+        self.assertEqual(duplicates, {"signer@test.com": ["signer_user", "signer_user2"]})
+
+        # Signers and watchers users are sorted and checked
+        api.group.create(groupname="myservice_watchers")
+        api.group.add_user(groupname="myservice_watchers", user=self.user)
+        view = SigningUsersCsv(self.portal, self.request)
+        users_data, _duplicates = view.get_users_data()
+        self.assertEqual(
+            users_data,
+            [
+                {
+                    "checked": True,
+                    "firstname": u"",
+                    "lastname": u"signer_user",
+                    "userid": "signer_user",
+                    "has_duplicate_email": True,
+                    "fullname": "",
+                    "email": "signer@test.com",
+                },
+                {
+                    "checked": False,
+                    "firstname": u"",
+                    "lastname": u"signer_user2",
+                    "userid": "signer_user2",
+                    "has_duplicate_email": True,
+                    "fullname": "",
+                    "email": "signer@test.com",
+                },
+                {
+                    "checked": False,
+                    "firstname": u"",
+                    "lastname": u"test_user_1_",
+                    "userid": "test_user_1_",
+                    "has_duplicate_email": False,
+                    "fullname": "",
+                    "email": "",
+                },
+            ],
+        )
+
+    # --- _get_selected_userids ---
+
+    def test_get_selected_userids_with_valid_json(self):
+        """Parses a JSON array of user IDs from the request form."""
+        self.request.form["selected_users"] = json.dumps(["user1", "user2"])
+        view = SigningUsersCsv(self.portal, self.request)
+        self.assertEqual(view._get_selected_userids(), ["user1", "user2"])
+
+    def test_get_selected_userids_with_empty_param(self):
+        """Returns empty list when selected_users is absent."""
+        view = SigningUsersCsv(self.portal, self.request)
+        self.assertEqual(view._get_selected_userids(), [])
+
+    def test_get_selected_userids_with_invalid_json(self):
+        """Returns empty list for malformed JSON."""
+        self.request.form["selected_users"] = "not-valid-json"
+        view = SigningUsersCsv(self.portal, self.request)
+        self.assertEqual(view._get_selected_userids(), [])
+
+    # --- _download_csv ---
+
+    def test_download_csv_no_selected_users(self):
+        """Shows warning and redirects when no users are selected."""
+        view = SigningUsersCsv(self.portal, self.request)
+        view._download_csv()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertIn("No users selected", messages[0].message)
+        self.assertEqual(messages[0].type, "warning")
+
+    def test_download_csv_generates_csv(self):
+        """Returns CSV content with headers and a row for each selected user."""
+        self.request.form["selected_users"] = json.dumps([self.user.getId()])
+        view = SigningUsersCsv(self.portal, self.request)
+        result = view._download_csv()
+        self.assertEqual(
+            result, "userid,email,lastname,firstname,fullname\r\nsigner_user,signer@test.com,signer_user,,\r\n"
+        )
+        self.assertIn("text/csv", self.request.RESPONSE.getHeader("Content-Type"))
+
+    # --- _send_emails ---
+
+    def test_send_emails_no_selected_users(self):
+        """Shows warning and redirects when no users are selected."""
+        view = SigningUsersCsv(self.portal, self.request)
+        view._send_emails()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertIn("No users selected", messages[0].message)
+        self.assertEqual(messages[0].type, "warning")
+
+    def test_send_emails_no_email_content(self):
+        """Shows error and redirects when signing users email content is not configured."""
+        set_registry_signing_users_email_content(u"")
+        self.request.form["selected_users"] = json.dumps([self.user.getId()])
+        view = SigningUsersCsv(self.portal, self.request)
+        view._send_emails()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0].message, u"Email content is not configured in the settings.")
+        self.assertEqual(messages[0].type, "error")
+
+    def test_send_emails_no_portal_from_email(self):
+        """Shows error and redirects to mail-controlpanel when portal from email is not set."""
+        self.request.form["selected_users"] = json.dumps([self.user.getId()])
+        view = SigningUsersCsv(self.portal, self.request)
+        view._send_emails()
+        messages = IStatusMessage(self.request).show()
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0].message, u"Portal from email is not configured.")
+        self.assertEqual(messages[0].type, "error")
+
+    def test_send_emails_success(self):
+        """Sends emails to all selected users and shows a success message."""
+        self.portal.manage_changeProperties({"email_from_address": "from@test.com"})
+        set_registry_signing_users_email_content(u"<p>Hello</p>")
+        self.request.form["selected_users"] = json.dumps([self.user.getId()])
+        view = SigningUsersCsv(self.portal, self.request)
+        with patch("imio.esign.browser.views.send_email", return_value=(True, None)):
+            view._send_emails()
+        messages = IStatusMessage(self.request).show()
+        success_msgs = [m for m in messages if m.type == "info"]
+        self.assertEqual(len(success_msgs), 1)
+        self.assertIn("Emails sent successfully", success_msgs[0].message)
+
+    def test_send_emails_user_with_no_email(self):
+        """Shows per-user warning when a selected user has no email address."""
+        self.portal.manage_changeProperties({"email_from_address": "from@test.com"})
+        set_registry_signing_users_email_content(u"<p>Hello</p>")
+        no_email_user = api.user.create(
+            email="placeholder@test.com", username="no_email_user", password="password1"  # noqa: S106
+        )
+        no_email_user.setMemberProperties({"email": ""})
+        self.request.form["selected_users"] = json.dumps([no_email_user.getId()])
+        view = SigningUsersCsv(self.portal, self.request)
+        view._send_emails()
+        messages = IStatusMessage(self.request).show()
+        no_email_msgs = [m for m in messages if "no email address" in m.message]
+        self.assertEqual(len(no_email_msgs), 1)
+        self.assertEqual(no_email_msgs[0].type, "warning")
+
+    # --- _render_email_content ---
+
+    def test_render_email_content(self):
+        """Renders a TAL template substituting values from user_data."""
+        template = u"<p tal:content=\"python: user_data['fullname']\">NAME</p>"
+        user_data = {
+            "userid": "testuser",
+            "email": "test@test.com",
+            "lastname": "Smith",
+            "firstname": "John",
+            "fullname": "John Smith",
+        }
+        view = SigningUsersCsv(self.portal, self.request)
+        result = view._render_email_content(template, user_data)
+        self.assertEqual(result, u"<p>John Smith</p>")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User filtering now also recognizes group-based "watcher" membership in addition to existing position checks, widening recipient inclusion where appropriate.
  * Broadened JSON parsing error handling for selection input to catch additional parsing issues.

* **Tests**
  * Added extensive tests covering user filtering, data aggregation, CSV export and selection parsing, plus email notification workflows, templates and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->