### PR TITLE
Fixed faceted viewlet broken because sessions format changed from list to OrderedDict.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ Changelog
 - Configured the `@@remove-from-esign-session` the same way as `@@remove-item-from-esign-session`
   so relying on an `available` method to show it only if a context is in a session.
   [gbastien]
+- Fixed faceted viewlet broken because sessions format changed from list to OrderedDict.
+  [gbastien]
 
 1.0a2 (2026-02-06)
 ------------------

--- a/src/imio/esign/browser/views.py
+++ b/src/imio/esign/browser/views.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from AccessControl import Unauthorized
-from copy import deepcopy
 from datetime import datetime
 from datetime import timedelta
 from imio.esign import _
@@ -224,7 +223,10 @@ class FacetedSessionInfoViewlet(ViewletBase):
             session_id = int(session_id)
         except (TypeError, ValueError):
             return {}
-        session = {session_id: get_session_info(session_id)}
+        session = {}
+        session_info = get_session_info(session_id)
+        if session_info:
+            session = {session_id: session_info}
         # caching
         self._cached_session = session
         return session

--- a/src/imio/esign/browser/views.py
+++ b/src/imio/esign/browser/views.py
@@ -13,6 +13,7 @@ from imio.esign.config import get_registry_parapheo_url
 from imio.esign.config import get_registry_signing_users_email_content
 from imio.esign.utils import create_external_session
 from imio.esign.utils import get_session_annotation
+from imio.esign.utils import get_session_info
 from imio.esign.utils import get_sessions_for
 from imio.esign.utils import get_state_description
 from imio.esign.utils import remove_session
@@ -215,18 +216,18 @@ class FacetedSessionInfoViewlet(ViewletBase):
 
     @property
     def sessions(self):
+        # caching
+        if hasattr(self, "_cached_session"):
+            return self._cached_session
         session_id = self.request.form.get("esign_session_id[]", None)
         try:
             session_id = int(session_id)
         except (TypeError, ValueError):
-            return []
-        sessions = get_session_annotation()["sessions"]
-        session = sessions.get(session_id)
-        if not session:
-            return []
-        session = deepcopy(session)
-        session["id"] = session_id
-        return [session]
+            return {}
+        session = get_session_info(session_id)
+        # caching
+        self._cached_session = session
+        return session
 
     def get_table_rows(self, column):
         """Get the table rows following the column"""

--- a/src/imio/esign/browser/views.py
+++ b/src/imio/esign/browser/views.py
@@ -224,7 +224,7 @@ class FacetedSessionInfoViewlet(ViewletBase):
             session_id = int(session_id)
         except (TypeError, ValueError):
             return {}
-        session = get_session_info(session_id)
+        session = {session_id: get_session_info(session_id)}
         # caching
         self._cached_session = session
         return session

--- a/src/imio/esign/tests/test_utils.py
+++ b/src/imio/esign/tests/test_utils.py
@@ -494,9 +494,9 @@ class TestUtils(unittest.TestCase):
         """Test getting info about a given session id."""
         annot = get_session_annotation()
         self.assertEqual(len(annot["sessions"]), 0)
-        self.assertIsNone(get_session_info(0))
-        self.assertIsNone(get_session_info(1))
-        self.assertIsNone(get_session_info(2))
+        self.assertEqual(get_session_info(0), {})
+        self.assertEqual(get_session_info(1), {})
+        self.assertEqual(get_session_info(2), {})
         signers = [
             ("user1", "user1@sign.com", "User 1", "Position 1"),
             ("user2", "user2@sign.com", "User 2", "Position 2"),

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -344,7 +344,6 @@ def get_session_info(session_id, portal=None, readonly=True):
         session = annot['sessions'][session_id]
         if readonly:
             session = deepcopy(session)
-        session = {session_id: session}
     return session
 
 

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -331,15 +331,21 @@ def get_session_annotation(portal=None):
     return annotations["imio.esign"]
 
 
-def get_session_info(session_id, portal=None):
+def get_session_info(session_id, portal=None, readonly=True):
     """Return a session info for a given numbering.
 
     :param session_id: the session id to return
     :param portal: portal if necessary to get the session annotation
+    :param readonly: return a copy of stored data to avoid modifying it
     """
     annot = get_session_annotation(portal=portal)
+    session = {}
     if session_id in annot['sessions']:
-        return annot['sessions'][session_id]
+        session = annot['sessions'][session_id]
+        if readonly:
+            session = deepcopy(session)
+        session = {session_id: session}
+    return session
 
 
 def remove_context_from_session(context_uids):


### PR DESCRIPTION
See #PARAF-345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored faceted viewlet after session format changes.
  * Improved session retrieval with caching for more consistent, faster views.
  * Missing sessions now return an empty result instead of null; session data is copied for read-only access to prevent accidental modification.

* **Documentation**
  * Added changelog entry noting the faceted viewlet fix and session-handling updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->