### PR TITLE
In sessions annotation, use a `PersistentMapping` instead a `dict` to store `signers` informations as the `status` will be updated.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,9 @@ Changelog
 1.0b3 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- In sessions annotation, use a `PersistentMapping` instead a `dict` to store
+  `signers` informations as the `status` will be updated.
+  [gbastien]
 
 1.0b2 (2026-03-26)
 ------------------

--- a/src/imio/esign/browser/table.py
+++ b/src/imio/esign/browser/table.py
@@ -103,7 +103,7 @@ class SignersColumn(Column):
             "<li>%s, %s%s (%s)</li>" % (
                 s.get("fullname", ""),
                 s.get("position"),
-                " (%s)" % s.get("status") if s.get("status") else "",
+                " (%s)" % translate(s.get("status"), domain="imio.esign", context=self.request) if s.get("status") else "",
                 s.get("email"), )
             for s in signers
         ]

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -267,7 +267,7 @@ def create_session(signers, seal=False, acroform=True, title=None, annot=None, d
         "sign_url": None,
         "signers": PersistentList(
             [
-                {"userid": userid, "email": email, "fullname": fullname, "position": position, "status": ""}
+                PersistentMapping({"userid": userid, "email": email, "fullname": fullname, "position": position, "status": ""})
                 for userid, email, fullname, position in signers
             ]
         ),


### PR DESCRIPTION
See #PARAF-387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Signer status messages now display in your preferred language through enhanced localization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->