### PR TITLE
Overrides check_permission to ignore UseRESTAPI and use JWT sso-apps token instead

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changelog
 
 - Set registry parapheo_url following is_test_url.
   [sgeulette]
+- Override `check_permission` method to `ExternalSessionFeedbackPost` service
+  to ignore `UseRESTAPI` permission and only check the validity of the authentication token.
+  [chris-adam]
 
 1.0b7 (2026-04-02)
 ------------------

--- a/src/imio/esign/configure.zcml
+++ b/src/imio/esign/configure.zcml
@@ -48,4 +48,16 @@
     provides="collective.compoundcriterion.interfaces.ICompoundCriterionFilter"
     name="files-belonging-to-a-given-session" />
 
+  <genericsetup:upgradeSteps
+      profile="imio.esign:default"
+      source="1000"
+      destination="1001"
+      >
+    <genericsetup:upgradeDepends
+        title="Apply rolemap"
+        description=""
+        import_steps="rolemap"
+        />
+  </genericsetup:upgradeSteps>
+
 </configure>

--- a/src/imio/esign/profiles/default/metadata.xml
+++ b/src/imio/esign/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1000</version>
+  <version>1001</version>
   <dependencies>
     <!--<dependency>profile-plone.app.dexterity:default</dependency>-->
     <dependency>profile-plone.restapi:default</dependency>

--- a/src/imio/esign/profiles/default/rolemap.xml
+++ b/src/imio/esign/profiles/default/rolemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<rolemap>
+  <permissions>
+    <permission name="plone.restapi: Use REST API" acquire="True">
+      <role name="Member"/>
+    </permission>
+  </permissions>
+</rolemap>

--- a/src/imio/esign/services/external_session_feedback.py
+++ b/src/imio/esign/services/external_session_feedback.py
@@ -6,6 +6,7 @@ from imio.esign.utils import get_session_annotation
 from imio.helpers.ws import verify_auth_token
 from plone.restapi.deserializer import json_body
 from plone.restapi.services import Service
+from zExceptions import Unauthorized
 
 
 class ExternalSessionFeedbackPost(Service):
@@ -19,9 +20,6 @@ class ExternalSessionFeedbackPost(Service):
             * "value": json dict contaaining sign URL or signer/refused emails
             * "message": "some message", optional message with feedback
         """
-        if not self.authorized():
-            self.request.response.setStatus(403)
-            return {"message": "Unauthorized access"}
         data = json_body(self.request)
         app_session_id = data.get("app_session_id")
         logger.info("External session feedback received: {}".format(data))
@@ -104,3 +102,7 @@ class ExternalSessionFeedbackPost(Service):
         if not token:
             return False
         return verify_auth_token(token, groups=["access_imio-apps-docs"])
+
+    def check_permission(self):
+        if not self.authorized():
+            raise Unauthorized("Unauthorized: Invalid or missing authentication token")

--- a/src/imio/esign/services/external_session_feedback.py
+++ b/src/imio/esign/services/external_session_feedback.py
@@ -93,7 +93,7 @@ class ExternalSessionFeedbackPost(Service):
             return {"message": str(e)}
         return {"message": "Information correctly handled"}
 
-    def authorized(self):
+    def _authorized(self):
         """Check if the user is authorized to access this service."""
         auth_header = getattr(self.request, "_auth", None)
         if not auth_header or not auth_header.startswith("Bearer "):
@@ -104,5 +104,5 @@ class ExternalSessionFeedbackPost(Service):
         return verify_auth_token(token, groups=["access_imio-apps-docs"])
 
     def check_permission(self):
-        if not self.authorized():
+        if not self._authorized():
             raise Unauthorized("Unauthorized: Invalid or missing authentication token")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External session feedback now returns a consistent Unauthorized response for missing/invalid authentication and relies solely on token validity for access checks.
* **Chores**
  * Updated site profile version and added an upgrade step.
  * Added a role mapping to grant the REST API permission to the Member role.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->