### PR TITLE
Improved ExternalSessionFeedback audit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.0b9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Improved ExternalSessionFeedback audit.
+  [chris-adam]
 
 
 1.0b8 (2026-05-08)

--- a/src/imio/esign/services/external_session_feedback.py
+++ b/src/imio/esign/services/external_session_feedback.py
@@ -85,7 +85,10 @@ class ExternalSessionFeedbackPost(Service):
             if session_update:
                 session.update(session_update)
                 session["last_update"] = datetime.now()
-            audit("session_feedback", "session={} code={} db_state={}".format(session_id, code, db_state))
+            audit(
+                "session_feedback",
+                'session={} code={} db_state={} data="{}"'.format(session_id, code, db_state, data),
+            )
 
         except Exception as e:
             self.request.response.setStatus(500)
@@ -104,5 +107,6 @@ class ExternalSessionFeedbackPost(Service):
         return verify_auth_token(token, groups=["access_imio-apps-docs"])
 
     def check_permission(self):
+        """Override the default permission check to implement token-based authentication."""
         if not self._authorized():
             raise Unauthorized("Unauthorized: Invalid or missing authentication token")


### PR DESCRIPTION
Testé en staging (avant d'afficher data au lieu de juste value et message):
> 260508 114815 I (fpa_esign) user=- ip=91.121.254.225 action=session_feedback session=19 code=21 db_state=to_sign value="{u'sign_session_url': u'https://simplycosi-1-test.trustsigneurope.com/login?tenantName=IMIO&sessionId=25671&step=195073'}" message="Sign session created successfully."
> 260508 115301 I (fpa_esign) user=- ip=91.121.254.225 action=session_feedback session=19 code=23 db_state=completed value="{}" message="All documents {'Modele de base S0018 test PARAF 431__9c0c391df5b04d8291392b518350e917.pdf': '012999700000014__9c0c391df5b04d8291392b518350e917'} were successfully uploaded to Webservice GED."
> 260508 115305 I (fpa_esign) user=- ip=91.121.254.225 action=session_feedback session=19 code=22 db_state=completed value="{u'remaining_users': [], u'signed_users': [u'chris.adam@imio.be']}" message="One new user amongst ['chris.adam@imio.be'] has signed the document(s)"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audit logging for session feedback operations to capture complete request data and context.

* **Documentation**
  * Updated changelog for version 1.0b9 with audit improvement entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->