### PR TITLE
Paraf 445/max session files

### DIFF
--- a/src/imio/esign/browser/actions.py
+++ b/src/imio/esign/browser/actions.py
@@ -52,7 +52,7 @@ class AddToSessionView(BrowserView):
             title=self.get_session_title(),
             watchers=self.get_watchers(),
             discriminators=self.get_discriminators(),
-        )
+        )[-1]
         # audit("add_to_session", "session={} context={} files={} signers={}".format(
         #     session_id, self.context.UID(), ",".join(files_uids), len(signers)))
         self._finished()

--- a/src/imio/esign/browser/actions.py
+++ b/src/imio/esign/browser/actions.py
@@ -29,7 +29,7 @@ class AddToSessionView(BrowserView):
         super(AddToSessionView, self).__init__(context, request)
 
     def _finished(self, failed_msgid="", mapping={}):
-        msgid = "Element added to session!"
+        msgid = "Element added to session(s) ${session_ids}!"
         msg_type = "info"
         if failed_msgid:
             msgid = failed_msgid
@@ -45,17 +45,17 @@ class AddToSessionView(BrowserView):
         if not signers:
             return self._finished(failed_msgid="Could not get signers to add to the session!")
         # watchers = self.get_watchers()
-        session_id, _session = add_files_to_session(
+        session_ids = add_files_to_session(
             signers=signers,
             # watchers=watchers,
             files_uids=files_uids,
             title=self.get_session_title(),
             watchers=self.get_watchers(),
             discriminators=self.get_discriminators(),
-        )[-1]
+        )
         # audit("add_to_session", "session={} context={} files={} signers={}".format(
         #     session_id, self.context.UID(), ",".join(files_uids), len(signers)))
-        self._finished()
+        self._finished(mapping={"session_ids": u", ".join([tup[0] for tup in session_ids])})
 
     def get_signers(self):
         """Get the list of held_positions to be used as signer.

--- a/src/imio/esign/browser/settings.py
+++ b/src/imio/esign/browser/settings.py
@@ -105,6 +105,15 @@ class IImioEsignSettings(Interface):
         required=True,
     )
 
+    max_session_files = schema.Int(
+        title=_("Max session files"),
+        description=_("Maximum number of files per session. If the number of files to be signed exceeds this "
+                      "limit, a new session will be created."),
+        default=25,
+        min=1,
+        required=True,
+    )
+
     external_watchers = schema.TextLine(
         title=_("External watchers emails"),
         description=_("Multiple values must be separated by a comma."),

--- a/src/imio/esign/browser/table.py
+++ b/src/imio/esign/browser/table.py
@@ -3,6 +3,7 @@
 from eea.facetednavigation.interfaces import IFacetedNavigable
 from html import escape
 from imio.esign import _
+from imio.esign.config import get_esign_registry_max_session_files
 from imio.esign.config import get_esign_registry_max_session_size
 from imio.esign.config import get_esign_registry_seal_code
 from imio.esign.config import get_esign_registry_seal_email
@@ -134,12 +135,24 @@ class FilesColumn(Column):
         )
         # size_label = u"%d/%d MB" % (size_mb, max_size_mb)
         size_label = u"%d MB" % size_mb
+        help_title = translate(
+            _(
+                "Session can contain max ${max_session_files} elements and have a max size of ${max_session_size} MB.",
+                mapping={
+                    "max_session_files": get_esign_registry_max_session_files(),
+                    "max_session_size": get_esign_registry_max_session_size()
+                },
+            ),
+            context=self.request,
+            domain="imio.esign",
+        )
         label = translate(
             _(
-                "Quick look (${count} element(s), total size: ${size})",
+                "Quick look (${count} element(s), total size: ${size}) <span title='${help_title}' class='far fa-question-circle' />",
                 mapping={
                     "count": count,
                     "size": u"<span%s>%s</span>" % (size_style, size_label),
+                    "help_title": help_title,
                 },
             ),
             context=self.request,

--- a/src/imio/esign/browser/table.py
+++ b/src/imio/esign/browser/table.py
@@ -187,7 +187,7 @@ class ActionsColumn(Column):
                 sessions_url=sessions_url,
                 session_id=session_id,
             )
-        if (item.get("state") in ("draft", "complete")
+        if (item.get("state") in ("draft", "draft_full")
                 and getMultiAdapter((portal, self.request),
                                     name="external-esign-session-create").may_create_external_sessions()):
             admin_buttons += u"""

--- a/src/imio/esign/browser/table.py
+++ b/src/imio/esign/browser/table.py
@@ -60,7 +60,8 @@ class StateColumn(Column):
         ))
         title = escape(translate(get_state_description(item.get("state", "")), context=self.request,
                                  domain="imio.esign"))
-        return (u"<span class='state-title state-title-{state_title_value}' title='{title}'>{state} <span class='far fa-question-circle' />"
+        return (u"<span class='state-title state-title-{state_title_value}' title='{title}'>{state} "
+                u"<span class='far fa-question-circle' />"
                 u"</span>".format(state=state, title=title, state_title_value=item.get("state")))
 
 
@@ -105,7 +106,8 @@ class SignersColumn(Column):
             "<li>%s, %s%s (%s)</li>" % (
                 safe_encode(s.get("fullname", "")),
                 safe_encode(s.get("position")),
-                " (%s)" % safe_encode(translate(s.get("status"), domain="imio.esign", context=self.request)) if s.get("status") else "",
+                " (%s)" % safe_encode(translate(s.get("status"), domain="imio.esign",
+                                                context=self.request)) if s.get("status") else "",
                 s.get("email"), )
             for s in signers
         ]
@@ -185,7 +187,7 @@ class ActionsColumn(Column):
                 sessions_url=sessions_url,
                 session_id=session_id,
             )
-        if (item.get("state") == "draft"
+        if (item.get("state") in ("draft", "complete")
                 and getMultiAdapter((portal, self.request),
                                     name="external-esign-session-create").may_create_external_sessions()):
             admin_buttons += u"""
@@ -199,7 +201,8 @@ class ActionsColumn(Column):
             )
         if check_zope_admin():
             admin_buttons += u"""
-            <a class="link-overlay-info" href="{sessions_url}/@@session-annotation-info?session_id={session_id}" target="_blank">
+            <a class="link-overlay-info" href="{sessions_url}/@@session-annotation-info?session_id={session_id}"
+            target="_blank">
                 <span class="fa fa-info-circle" title="Annotation info"></span>
             </a>
             """.format(

--- a/src/imio/esign/config.py
+++ b/src/imio/esign/config.py
@@ -39,6 +39,10 @@ def get_esign_registry_max_session_size(default=100):
     return api.portal.get_registry_record("imio.esign.max_session_size", default=default)
 
 
+def get_esign_registry_max_session_files(default=25):
+    return api.portal.get_registry_record("imio.esign.max_session_files", default=default)
+
+
 def get_esign_registry_external_watchers():
     value = api.portal.get_registry_record("imio.esign.external_watchers", default="")
     if not value:
@@ -80,6 +84,10 @@ def set_esign_registry_signing_users_email_content(value):
 
 def set_esign_registry_max_session_size(value):
     api.portal.set_registry_record("imio.esign.max_session_size", value)
+
+
+def set_esign_registry_max_session_files(value):
+    api.portal.set_registry_record("imio.esign.max_session_files", value)
 
 
 def set_esign_registry_external_watchers(value):

--- a/src/imio/esign/configure.zcml
+++ b/src/imio/esign/configure.zcml
@@ -10,33 +10,12 @@
 
   <include file="events.zcml" />
   <include file="permissions.zcml" />
+  <include file="profiles.zcml" />
+  <include file="upgrades.zcml" />
 
   <include package="imio.fpaudit"/>
   <include package=".browser" />
   <include package=".services" />
-
-  <genericsetup:registerProfile
-      name="default"
-      title="imio.esign"
-      directory="profiles/default"
-      description="Installs the imio.esign add-on."
-      provides="Products.GenericSetup.interfaces.EXTENSION"
-      post_handler=".setuphandlers.post_install"
-      />
-
-  <genericsetup:registerProfile
-      name="uninstall"
-      title="imio.esign (uninstall)"
-      directory="profiles/uninstall"
-      description="Uninstalls the imio.esign add-on."
-      provides="Products.GenericSetup.interfaces.EXTENSION"
-      post_handler=".setuphandlers.uninstall"
-      />
-
-  <utility
-      factory=".setuphandlers.HiddenProfiles"
-      name="imio.esign-hiddenprofiles"
-      />
 
   <adapter
     factory=".adapters.DefaultContextUidProvider"
@@ -47,17 +26,5 @@
     factory=".adapters.FilesBelongingToAGivenSession"
     provides="collective.compoundcriterion.interfaces.ICompoundCriterionFilter"
     name="files-belonging-to-a-given-session" />
-
-  <genericsetup:upgradeSteps
-      profile="imio.esign:default"
-      source="1000"
-      destination="1001"
-      >
-    <genericsetup:upgradeDepends
-        title="Apply rolemap"
-        description=""
-        import_steps="rolemap"
-        />
-  </genericsetup:upgradeSteps>
 
 </configure>

--- a/src/imio/esign/locales/en/LC_MESSAGES/imio.esign.po
+++ b/src/imio/esign/locales/en/LC_MESSAGES/imio.esign.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-04-03 11:53+0000\n"
+"POT-Creation-Date: 2026-05-26 13:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,11 +15,11 @@ msgstr ""
 "Domain: imio.dashboard\n"
 "X-is-fallback-for: en-au en-ca en-gb en-us\n"
 
-#: ../browser/views.py:312
+#: ../browser/views.py:317
 msgid "A file identifier must be passed in the url !"
 msgstr ""
 
-#: ../browser/table.py:161
+#: ../browser/table.py:206
 msgid "Actions"
 msgstr ""
 
@@ -39,11 +39,11 @@ msgstr ""
 msgid "Confirm Email Sending"
 msgstr ""
 
-#: ../browser/table.py:194
+#: ../browser/table.py:239
 msgid "Create external session"
 msgstr ""
 
-#: ../browser/table.py:180
+#: ../browser/table.py:225
 msgid "Delete session"
 msgstr ""
 
@@ -55,12 +55,12 @@ msgstr ""
 msgid "Element removed from session!"
 msgstr ""
 
-#: ../browser/templates/macros.pt:49
+#: ../browser/templates/macros.pt:50
 #: ../browser/templates/signing_users.pt:215
 msgid "Email"
 msgstr ""
 
-#: ../browser/views.py:581
+#: ../browser/views.py:586
 msgid "Email content is not configured in the settings."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "Email:"
 msgstr ""
 
-#: ../browser/views.py:641
+#: ../browser/views.py:646
 msgid "Emails sent successfully to ${count} users."
 msgstr ""
 
@@ -88,23 +88,23 @@ msgstr ""
 msgid "Enabled?"
 msgstr ""
 
-#: ../browser/views.py:189
+#: ../browser/views.py:194
 msgid "Error while sending session: ${error}"
 msgstr ""
 
-#: ../browser/views.py:184
+#: ../browser/views.py:189
 msgid "External session sent successfully!"
 msgstr ""
 
-#: ../browser/settings.py:109
+#: ../browser/settings.py:118
 msgid "External watchers emails"
 msgstr ""
 
-#: ../browser/views.py:628
+#: ../browser/views.py:633
 msgid "Failed to send email to ${userid}."
 msgstr ""
 
-#: ../browser/views.py:648
+#: ../browser/views.py:653
 msgid "Failed to send emails to ${count} users."
 msgstr ""
 
@@ -112,7 +112,7 @@ msgstr ""
 msgid "File URL download domain"
 msgstr ""
 
-#: ../browser/table.py:114
+#: ../browser/table.py:121
 msgid "Files"
 msgstr ""
 
@@ -124,15 +124,11 @@ msgstr ""
 msgid "Full Name"
 msgstr ""
 
-#: ../browser/templates/macros.pt:47
+#: ../browser/templates/macros.pt:48
 msgid "Full name"
 msgstr ""
 
-#: ../browser/table.py:19
-msgid "ID"
-msgstr ""
-
-#: ../browser/settings.py:119
+#: ../browser/settings.py:128
 #: ../profiles/default/controlpanel.xml
 msgid "Imio Esign Settings"
 msgstr ""
@@ -141,7 +137,7 @@ msgstr ""
 msgid "Important:"
 msgstr ""
 
-#: ../configure.zcml:25
+#: ../profiles.zcml:13
 msgid "Installs the imio.esign add-on."
 msgstr ""
 
@@ -157,8 +153,8 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: ../browser/table.py:147
-#: ../browser/templates/macros.pt:20
+#: ../browser/table.py:190
+#: ../browser/templates/macros.pt:21
 msgid "Last update"
 msgstr ""
 
@@ -166,15 +162,23 @@ msgstr ""
 msgid "List of electronic signing sessions"
 msgstr ""
 
+#: ../browser/settings.py:109
+msgid "Max session files"
+msgstr ""
+
 #: ../browser/settings.py:100
 msgid "Max session size (MB)"
+msgstr ""
+
+#: ../browser/settings.py:110
+msgid "Maximum number of files per session. If the number of files to be signed exceeds this limit, a new session will be created."
 msgstr ""
 
 #: ../browser/settings.py:101
 msgid "Maximum size of the session in megabytes. If the total size of files to be signed exceeds this limit, a new session will be created."
 msgstr ""
 
-#: ../browser/settings.py:110
+#: ../browser/settings.py:119
 msgid "Multiple values must be separated by a comma."
 msgstr ""
 
@@ -186,35 +190,31 @@ msgstr ""
 msgid "No files"
 msgstr ""
 
-#: ../browser/templates/session_files.pt:5
-msgid "Quick look (${count} element(s), total size: ${size})"
-msgstr ""
-
-#: ../browser/views.py:178
+#: ../browser/views.py:183
 msgid "No files found to be sent ! Session ${id} not sent."
 msgstr ""
 
-#: ../browser/views.py:164
+#: ../browser/views.py:169
 msgid "No seal code defined in configuration ! Session ${id} not sent."
 msgstr ""
 
-#: ../browser/views.py:171
+#: ../browser/views.py:176
 msgid "No seal email defined in configuration ! Session ${id} not sent."
 msgstr ""
 
-#: ../browser/views.py:123
+#: ../browser/views.py:128
 msgid "No session ID provided!"
 msgstr ""
 
-#: ../browser/views.py:536
+#: ../browser/views.py:541
 msgid "No users selected for CSV download."
 msgstr ""
 
-#: ../browser/views.py:575
+#: ../browser/views.py:580
 msgid "No users selected for email sending."
 msgstr ""
 
-#: ../browser/templates/sessions.pt:44
+#: ../browser/templates/sessions.pt:38
 msgid "Open eSign platform"
 msgstr ""
 
@@ -222,16 +222,20 @@ msgstr ""
 msgid "Parapheo url"
 msgstr ""
 
-#: ../browser/views.py:590
+#: ../browser/views.py:595
 msgid "Portal from email is not configured."
 msgstr ""
 
-#: ../browser/templates/macros.pt:48
+#: ../browser/templates/macros.pt:49
 msgid "Position"
 msgstr ""
 
 #: ../browser/actions.py:71
 msgid "Problem getting signers: \"${error}\")!"
+msgstr ""
+
+#: ../browser/table.py:150
+msgid "Quick look (${count} element(s), total size: ${size}) <span title='${help_title}' class='far fa-question-circle' />"
 msgstr ""
 
 #: ../profiles/default/actions.xml
@@ -254,8 +258,8 @@ msgstr ""
 msgid "Seal email"
 msgstr ""
 
-#: ../browser/table.py:80
-#: ../browser/templates/macros.pt:27
+#: ../browser/table.py:85
+#: ../browser/templates/macros.pt:28
 msgid "Sealed"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "Send Emails"
 msgstr ""
 
-#: ../utils.py:160
+#: ../utils.py:207
 msgid "Session ${id}"
 msgstr ""
 
@@ -283,7 +287,11 @@ msgstr ""
 msgid "Session ID"
 msgstr ""
 
-#: ../browser/views.py:131
+#: ../browser/table.py:139
+msgid "Session can contain max ${max_session_files} elements and have a max size of ${max_session_size} MB."
+msgstr ""
+
+#: ../browser/views.py:136
 msgid "Session deleted successfully!"
 msgstr ""
 
@@ -291,7 +299,7 @@ msgstr ""
 msgid "Session information (${icon_url} Parapheo)"
 msgstr ""
 
-#: ../browser/views.py:133
+#: ../browser/views.py:138
 msgid "Session not found!"
 msgstr ""
 
@@ -299,7 +307,7 @@ msgstr ""
 msgid "Session not yet sent."
 msgstr ""
 
-#: ../browser/views.py:157
+#: ../browser/views.py:162
 msgid "Session with ID ${id} doesn't exist anymore !"
 msgstr ""
 
@@ -315,12 +323,12 @@ msgstr ""
 msgid "Sign url not yet received."
 msgstr ""
 
-#: ../browser/views.py:364
+#: ../browser/views.py:369
 msgid "Signed file download"
 msgstr ""
 
-#: ../browser/table.py:95
-#: ../browser/templates/macros.pt:41
+#: ../browser/table.py:100
+#: ../browser/templates/macros.pt:42
 msgid "Signers"
 msgstr ""
 
@@ -328,24 +336,24 @@ msgstr ""
 msgid "Signing Users: Export CSV"
 msgstr ""
 
-#: ../browser/table.py:50
+#: ../browser/table.py:54
 #: ../browser/templates/macros.pt:11
 msgid "State"
 msgstr ""
 
-#: ../browser/templates/macros.pt:50
+#: ../browser/templates/macros.pt:51
 msgid "Status"
 msgstr ""
 
-#: ../browser/views.py:340
+#: ../browser/views.py:345
 msgid "The corresponding file content cannot be retrieved (${uid}) !"
 msgstr ""
 
-#: ../browser/views.py:320
+#: ../browser/views.py:325
 msgid "The corresponding file identifier cannot be retrieved (${uid}) !"
 msgstr ""
 
-#: ../browser/views.py:332
+#: ../browser/views.py:337
 msgid "The download period for this file has expired (was ${valid_date}) !"
 msgstr ""
 
@@ -381,7 +389,7 @@ msgstr ""
 msgid "The session is ready to be signed in Paraphéo."
 msgstr ""
 
-#: ../browser/views.py:316
+#: ../browser/views.py:321
 msgid "This file identifier is not correct !"
 msgstr ""
 
@@ -397,8 +405,8 @@ msgstr ""
 msgid "This will remove this element or configured sub elements from the relevant esign session"
 msgstr ""
 
-#: ../browser/table.py:66
-#: ../browser/templates/macros.pt:34
+#: ../browser/table.py:71
+#: ../browser/templates/macros.pt:35
 msgid "Title"
 msgstr ""
 
@@ -406,7 +414,7 @@ msgstr ""
 msgid "URL domain where the file can be downloaded."
 msgstr ""
 
-#: ../configure.zcml:34
+#: ../profiles.zcml:22
 msgid "Uninstalls the imio.esign add-on."
 msgstr ""
 
@@ -414,7 +422,7 @@ msgstr ""
 msgid "Used in signers email template."
 msgstr ""
 
-#: ../browser/views.py:599
+#: ../browser/views.py:604
 msgid "User ${userid} has no email address configured. Skipping."
 msgstr ""
 
@@ -446,7 +454,7 @@ msgstr ""
 msgid "VAT number used for esign billing (BE0123456789)."
 msgstr ""
 
-#: ../browser/table.py:210
+#: ../browser/table.py:256
 msgid "View session in dashboard"
 msgstr ""
 
@@ -462,7 +470,7 @@ msgstr ""
 msgid "You are about to send emails to"
 msgstr ""
 
-#: ../browser/views.py:614
+#: ../browser/views.py:619
 msgid "You have been invited to Paraphéo"
 msgstr ""
 
@@ -478,11 +486,11 @@ msgstr "Errored"
 msgid "finalized"
 msgstr ""
 
-#: ../configure.zcml:25
+#: ../profiles.zcml:13
 msgid "imio.esign"
 msgstr ""
 
-#: ../configure.zcml:34
+#: ../profiles.zcml:22
 msgid "imio.esign (uninstall)"
 msgstr ""
 

--- a/src/imio/esign/locales/fr/LC_MESSAGES/imio.esign.po
+++ b/src/imio/esign/locales/fr/LC_MESSAGES/imio.esign.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-04-03 11:53+0000\n"
+"POT-Creation-Date: 2026-05-26 13:04+0000\n"
 "PO-Revision-Date: 2016-02-22 15:20+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -16,11 +16,11 @@ msgstr ""
 "Language: fr\n"
 "X-Generator: Poedit 1.8.4\n"
 
-#: ../browser/views.py:312
+#: ../browser/views.py:317
 msgid "A file identifier must be passed in the url !"
 msgstr "Un identifiant de fichier doit être inclus dans l'URL !"
 
-#: ../browser/table.py:161
+#: ../browser/table.py:206
 msgid "Actions"
 msgstr "Actions"
 
@@ -40,11 +40,11 @@ msgstr "Annuler"
 msgid "Confirm Email Sending"
 msgstr "Confirmer l'envoi des emails"
 
-#: ../browser/table.py:194
+#: ../browser/table.py:239
 msgid "Create external session"
 msgstr "Envoyer dans Paraphéo"
 
-#: ../browser/table.py:180
+#: ../browser/table.py:225
 msgid "Delete session"
 msgstr "Effacer la session"
 
@@ -56,12 +56,12 @@ msgstr "Désélectionner tout"
 msgid "Element removed from session!"
 msgstr "Élément retiré de la session !"
 
-#: ../browser/templates/macros.pt:49
+#: ../browser/templates/macros.pt:50
 #: ../browser/templates/signing_users.pt:215
 msgid "Email"
 msgstr "E-mail"
 
-#: ../browser/views.py:581
+#: ../browser/views.py:586
 msgid "Email content is not configured in the settings."
 msgstr "Le modèle d'email n'est pas configuré dans les paramètres."
 
@@ -81,7 +81,7 @@ msgstr "Email du compte du fournisseur eidas contenant l'image du sceau."
 msgid "Email:"
 msgstr "Email:"
 
-#: ../browser/views.py:641
+#: ../browser/views.py:646
 msgid "Emails sent successfully to ${count} users."
 msgstr "Emails envoyés avec succès à ${count} utilisateurs."
 
@@ -89,23 +89,23 @@ msgstr "Emails envoyés avec succès à ${count} utilisateurs."
 msgid "Enabled?"
 msgstr "Activé?"
 
-#: ../browser/views.py:189
+#: ../browser/views.py:194
 msgid "Error while sending session: ${error}"
 msgstr "Erreur lors de l'envoi de la session : ${error}"
 
-#: ../browser/views.py:184
+#: ../browser/views.py:189
 msgid "External session sent successfully!"
 msgstr "Session externe envoyée avec succès !"
 
-#: ../browser/settings.py:109
+#: ../browser/settings.py:118
 msgid "External watchers emails"
 msgstr "Liste d'emails d'observateurs externes"
 
-#: ../browser/views.py:628
+#: ../browser/views.py:633
 msgid "Failed to send email to ${userid}."
 msgstr "Échec de l'envoi de l'email pour ${userid}."
 
-#: ../browser/views.py:648
+#: ../browser/views.py:653
 msgid "Failed to send emails to ${count} users."
 msgstr "Échec de l'envoi des emails pour ${count} utilisateurs."
 
@@ -113,7 +113,7 @@ msgstr "Échec de l'envoi des emails pour ${count} utilisateurs."
 msgid "File URL download domain"
 msgstr "Nom de domaine de téléchargement"
 
-#: ../browser/table.py:114
+#: ../browser/table.py:121
 msgid "Files"
 msgstr "Fichiers"
 
@@ -125,15 +125,11 @@ msgstr "Prénom"
 msgid "Full Name"
 msgstr "Nom complet"
 
-#: ../browser/templates/macros.pt:47
+#: ../browser/templates/macros.pt:48
 msgid "Full name"
 msgstr "Nom"
 
-#: ../browser/table.py:19
-msgid "ID"
-msgstr "Identifiant"
-
-#: ../browser/settings.py:119
+#: ../browser/settings.py:128
 #: ../profiles/default/controlpanel.xml
 msgid "Imio Esign Settings"
 msgstr "Configuration du module de signature externe"
@@ -142,7 +138,7 @@ msgstr "Configuration du module de signature externe"
 msgid "Important:"
 msgstr "Important:"
 
-#: ../configure.zcml:25
+#: ../profiles.zcml:13
 msgid "Installs the imio.esign add-on."
 msgstr "Installs the imio.esign add-on."
 
@@ -158,8 +154,8 @@ msgstr "Active/désactive la fonctionnalité globalement sur le site."
 msgid "Last Name"
 msgstr "Nom"
 
-#: ../browser/table.py:147
-#: ../browser/templates/macros.pt:20
+#: ../browser/table.py:190
+#: ../browser/templates/macros.pt:21
 msgid "Last update"
 msgstr "Dernière mise à jour"
 
@@ -167,15 +163,23 @@ msgstr "Dernière mise à jour"
 msgid "List of electronic signing sessions"
 msgstr "Paraphéo: Liste des sessions de signatures électroniques"
 
+#: ../browser/settings.py:109
+msgid "Max session files"
+msgstr ""
+
 #: ../browser/settings.py:100
 msgid "Max session size (MB)"
 msgstr "Taille maximum de la session en MB"
+
+#: ../browser/settings.py:110
+msgid "Maximum number of files per session. If the number of files to be signed exceeds this limit, a new session will be created."
+msgstr ""
 
 #: ../browser/settings.py:101
 msgid "Maximum size of the session in megabytes. If the total size of files to be signed exceeds this limit, a new session will be created."
 msgstr "Si la taille totale des fichiers à signer dépasse cette limite, une nouvelle session sera créée."
 
-#: ../browser/settings.py:110
+#: ../browser/settings.py:119
 msgid "Multiple values must be separated by a comma."
 msgstr "Les valeurs multiples doivent être séparées par une virgule."
 
@@ -187,35 +191,31 @@ msgstr "Non"
 msgid "No files"
 msgstr "Aucun fichier"
 
-#: ../browser/templates/session_files.pt:5
-msgid "Quick look (${count} element(s), total size: ${size})"
-msgstr "${count} élément(s), taille: ${size}"
-
-#: ../browser/views.py:178
+#: ../browser/views.py:183
 msgid "No files found to be sent ! Session ${id} not sent."
 msgstr "Aucun fichier référencé n'a été trouvé ! La session ${id} n'a pas été envoyée."
 
-#: ../browser/views.py:164
+#: ../browser/views.py:169
 msgid "No seal code defined in configuration ! Session ${id} not sent."
 msgstr "Aucun code de sceau défini dans la configuration ! La session ${id} n'a pas été envoyée."
 
-#: ../browser/views.py:171
+#: ../browser/views.py:176
 msgid "No seal email defined in configuration ! Session ${id} not sent."
 msgstr "Aucun email de sceau défini dans la configuration ! La session ${id} n'a pas été envoyée."
 
-#: ../browser/views.py:123
+#: ../browser/views.py:128
 msgid "No session ID provided!"
 msgstr "Aucun identifiant de session fourni !"
 
-#: ../browser/views.py:536
+#: ../browser/views.py:541
 msgid "No users selected for CSV download."
 msgstr "Aucun utilisateur sélectionné pour le téléchargement du CSV."
 
-#: ../browser/views.py:575
+#: ../browser/views.py:580
 msgid "No users selected for email sending."
 msgstr "Aucun utilisateur sélectionné pour l'envoi d'emails."
 
-#: ../browser/templates/sessions.pt:44
+#: ../browser/templates/sessions.pt:38
 msgid "Open eSign platform"
 msgstr "Ouvrir la plateforme de signature électronique"
 
@@ -223,17 +223,21 @@ msgstr "Ouvrir la plateforme de signature électronique"
 msgid "Parapheo url"
 msgstr "Url de Paraphéo"
 
-#: ../browser/views.py:590
+#: ../browser/views.py:595
 msgid "Portal from email is not configured."
 msgstr "L'adresse d'expéditeur du site n'est pas configurée"
 
-#: ../browser/templates/macros.pt:48
+#: ../browser/templates/macros.pt:49
 msgid "Position"
 msgstr "Fonction"
 
 #: ../browser/actions.py:71
 msgid "Problem getting signers: \"${error}\")!"
 msgstr "Problème pour obtenir les signataires : \"${error}\" !"
+
+#: ../browser/table.py:150
+msgid "Quick look (${count} element(s), total size: ${size}) <span title='${help_title}' class='far fa-question-circle' />"
+msgstr "${count} élément(s), taille: ${size} <span title='${help_title}' class='far fa-question-circle' />"
 
 #: ../profiles/default/actions.xml
 msgid "Remove from esign session"
@@ -255,8 +259,8 @@ msgstr "Code fourni par le fournisseur eidas."
 msgid "Seal email"
 msgstr "Email du compte avec l'image du sceau"
 
-#: ../browser/table.py:80
-#: ../browser/templates/macros.pt:27
+#: ../browser/table.py:85
+#: ../browser/templates/macros.pt:28
 msgid "Sealed"
 msgstr "Sceau"
 
@@ -276,7 +280,7 @@ msgstr "Sélectionnés:"
 msgid "Send Emails"
 msgstr "Envoyer des emails"
 
-#: ../utils.py:160
+#: ../utils.py:207
 msgid "Session ${id}"
 msgstr "Session ${id}"
 
@@ -284,7 +288,11 @@ msgstr "Session ${id}"
 msgid "Session ID"
 msgstr "Identifiant"
 
-#: ../browser/views.py:131
+#: ../browser/table.py:139
+msgid "Session can contain max ${max_session_files} elements and have a max size of ${max_session_size} MB."
+msgstr "Une session peut contenir maximum ${max_session_files} éléments pour une taille totale maximum de ${max_session_size} MB."
+
+#: ../browser/views.py:136
 msgid "Session deleted successfully!"
 msgstr "Session effacée avec succès !"
 
@@ -292,7 +300,7 @@ msgstr "Session effacée avec succès !"
 msgid "Session information (${icon_url} Parapheo)"
 msgstr "Session de signature électronique (${icon_url} Paraphéo)"
 
-#: ../browser/views.py:133
+#: ../browser/views.py:138
 msgid "Session not found!"
 msgstr "Session non trouvée !"
 
@@ -300,7 +308,7 @@ msgstr "Session non trouvée !"
 msgid "Session not yet sent."
 msgstr "La session n'a pas encore été envoyée."
 
-#: ../browser/views.py:157
+#: ../browser/views.py:162
 msgid "Session with ID ${id} doesn't exist anymore !"
 msgstr "La session avec l'ID ${id} n'existe plus !"
 
@@ -316,12 +324,12 @@ msgstr "Méthode de signature utilisée pour spécifier la méthode de signature
 msgid "Sign url not yet received."
 msgstr "Le lien de la session de signature n'a pas encore été reçu."
 
-#: ../browser/views.py:364
+#: ../browser/views.py:369
 msgid "Signed file download"
 msgstr "Téléchargement du fichier signé"
 
-#: ../browser/table.py:95
-#: ../browser/templates/macros.pt:41
+#: ../browser/table.py:100
+#: ../browser/templates/macros.pt:42
 msgid "Signers"
 msgstr "Signataires"
 
@@ -329,24 +337,24 @@ msgstr "Signataires"
 msgid "Signing Users: Export CSV"
 msgstr "Signataires: csv pour WaCo et invitation Paraphéo"
 
-#: ../browser/table.py:50
+#: ../browser/table.py:54
 #: ../browser/templates/macros.pt:11
 msgid "State"
 msgstr "État"
 
-#: ../browser/templates/macros.pt:50
+#: ../browser/templates/macros.pt:51
 msgid "Status"
 msgstr "Statut"
 
-#: ../browser/views.py:340
+#: ../browser/views.py:345
 msgid "The corresponding file content cannot be retrieved (${uid}) !"
 msgstr "Le contenu du fichier correspondant ne peut pas être récupéré (${uid}) !"
 
-#: ../browser/views.py:320
+#: ../browser/views.py:325
 msgid "The corresponding file identifier cannot be retrieved (${uid}) !"
 msgstr "L'identifiant du fichier n'a pas été trouvé (${uid}) !"
 
-#: ../browser/views.py:332
+#: ../browser/views.py:337
 msgid "The download period for this file has expired (was ${valid_date}) !"
 msgstr "La période de téléchargement de ce fichier a expiré le ${valid_date} !"
 
@@ -382,7 +390,7 @@ msgstr "La session est en préparation pour être envoyée dans Paraphéo par un
 msgid "The session is ready to be signed in Paraphéo."
 msgstr "La session est prête pour signature dans Paraphéo."
 
-#: ../browser/views.py:316
+#: ../browser/views.py:321
 msgid "This file identifier is not correct !"
 msgstr "Le format de cet identifiant de fichier n'est pas correct !"
 
@@ -398,8 +406,8 @@ msgstr "Ceci va supprimer l'élement courant de la session de signature"
 msgid "This will remove this element or configured sub elements from the relevant esign session"
 msgstr "Cela retirera cet élément ou les sous-éléments configurés de la session de signature"
 
-#: ../browser/table.py:66
-#: ../browser/templates/macros.pt:34
+#: ../browser/table.py:71
+#: ../browser/templates/macros.pt:35
 msgid "Title"
 msgstr "Titre"
 
@@ -407,7 +415,7 @@ msgstr "Titre"
 msgid "URL domain where the file can be downloaded."
 msgstr "URL du domaine où un fichier signé peut être téléchargé (https://xxx)."
 
-#: ../configure.zcml:34
+#: ../profiles.zcml:22
 msgid "Uninstalls the imio.esign add-on."
 msgstr "Uninstalls the imio.esign add-on."
 
@@ -415,7 +423,7 @@ msgstr "Uninstalls the imio.esign add-on."
 msgid "Used in signers email template."
 msgstr "Utilisée dans le template d'email pour les signataires."
 
-#: ../browser/views.py:599
+#: ../browser/views.py:604
 msgid "User ${userid} has no email address configured. Skipping."
 msgstr "L'utilisateur ${userid} n'a pas d'adresse e-mail configurée. Ignoré."
 
@@ -447,7 +455,7 @@ msgstr "Le numéro de TVA doit commencer par 'BE'"
 msgid "VAT number used for esign billing (BE0123456789)."
 msgstr "Numéro de TVA utilisé pour la facturation esign (BE0123456789)."
 
-#: ../browser/table.py:210
+#: ../browser/table.py:256
 msgid "View session in dashboard"
 msgstr "Voir la session dans un tableau de bord"
 
@@ -463,7 +471,7 @@ msgstr "Oui"
 msgid "You are about to send emails to"
 msgstr "Vous êtes sur le point d'envoyer des emails à"
 
-#: ../browser/views.py:614
+#: ../browser/views.py:619
 msgid "You have been invited to Paraphéo"
 msgstr "Vous êtes invité à activer votre compte sur Paraphéo"
 
@@ -479,11 +487,11 @@ msgstr "En erreur"
 msgid "finalized"
 msgstr "Finalisée"
 
-#: ../configure.zcml:25
+#: ../profiles.zcml:13
 msgid "imio.esign"
 msgstr "imio.esign"
 
-#: ../configure.zcml:34
+#: ../profiles.zcml:22
 msgid "imio.esign (uninstall)"
 msgstr "imio.esign (uninstall)"
 

--- a/src/imio/esign/locales/imio.esign.pot
+++ b/src/imio/esign/locales/imio.esign.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-04-03 11:53+0000\n"
+"POT-Creation-Date: 2026-05-26 13:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,11 +15,11 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ../browser/views.py:312
+#: ../browser/views.py:317
 msgid "A file identifier must be passed in the url !"
 msgstr ""
 
-#: ../browser/table.py:161
+#: ../browser/table.py:206
 msgid "Actions"
 msgstr ""
 
@@ -39,11 +39,11 @@ msgstr ""
 msgid "Confirm Email Sending"
 msgstr ""
 
-#: ../browser/table.py:194
+#: ../browser/table.py:239
 msgid "Create external session"
 msgstr ""
 
-#: ../browser/table.py:180
+#: ../browser/table.py:225
 msgid "Delete session"
 msgstr ""
 
@@ -55,12 +55,12 @@ msgstr ""
 msgid "Element removed from session!"
 msgstr ""
 
-#: ../browser/templates/macros.pt:49
+#: ../browser/templates/macros.pt:50
 #: ../browser/templates/signing_users.pt:215
 msgid "Email"
 msgstr ""
 
-#: ../browser/views.py:581
+#: ../browser/views.py:586
 msgid "Email content is not configured in the settings."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "Email:"
 msgstr ""
 
-#: ../browser/views.py:641
+#: ../browser/views.py:646
 msgid "Emails sent successfully to ${count} users."
 msgstr ""
 
@@ -88,23 +88,23 @@ msgstr ""
 msgid "Enabled?"
 msgstr ""
 
-#: ../browser/views.py:189
+#: ../browser/views.py:194
 msgid "Error while sending session: ${error}"
 msgstr ""
 
-#: ../browser/views.py:184
+#: ../browser/views.py:189
 msgid "External session sent successfully!"
 msgstr ""
 
-#: ../browser/settings.py:109
+#: ../browser/settings.py:118
 msgid "External watchers emails"
 msgstr ""
 
-#: ../browser/views.py:628
+#: ../browser/views.py:633
 msgid "Failed to send email to ${userid}."
 msgstr ""
 
-#: ../browser/views.py:648
+#: ../browser/views.py:653
 msgid "Failed to send emails to ${count} users."
 msgstr ""
 
@@ -112,7 +112,7 @@ msgstr ""
 msgid "File URL download domain"
 msgstr ""
 
-#: ../browser/table.py:114
+#: ../browser/table.py:121
 msgid "Files"
 msgstr ""
 
@@ -124,15 +124,11 @@ msgstr ""
 msgid "Full Name"
 msgstr ""
 
-#: ../browser/templates/macros.pt:47
+#: ../browser/templates/macros.pt:48
 msgid "Full name"
 msgstr ""
 
-#: ../browser/table.py:19
-msgid "ID"
-msgstr ""
-
-#: ../browser/settings.py:119
+#: ../browser/settings.py:128
 #: ../profiles/default/controlpanel.xml
 msgid "Imio Esign Settings"
 msgstr ""
@@ -141,7 +137,7 @@ msgstr ""
 msgid "Important:"
 msgstr ""
 
-#: ../configure.zcml:25
+#: ../profiles.zcml:13
 msgid "Installs the imio.esign add-on."
 msgstr ""
 
@@ -157,8 +153,8 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: ../browser/table.py:147
-#: ../browser/templates/macros.pt:20
+#: ../browser/table.py:190
+#: ../browser/templates/macros.pt:21
 msgid "Last update"
 msgstr ""
 
@@ -166,15 +162,23 @@ msgstr ""
 msgid "List of electronic signing sessions"
 msgstr ""
 
+#: ../browser/settings.py:109
+msgid "Max session files"
+msgstr ""
+
 #: ../browser/settings.py:100
 msgid "Max session size (MB)"
+msgstr ""
+
+#: ../browser/settings.py:110
+msgid "Maximum number of files per session. If the number of files to be signed exceeds this limit, a new session will be created."
 msgstr ""
 
 #: ../browser/settings.py:101
 msgid "Maximum size of the session in megabytes. If the total size of files to be signed exceeds this limit, a new session will be created."
 msgstr ""
 
-#: ../browser/settings.py:110
+#: ../browser/settings.py:119
 msgid "Multiple values must be separated by a comma."
 msgstr ""
 
@@ -186,35 +190,31 @@ msgstr ""
 msgid "No files"
 msgstr ""
 
-#: ../browser/templates/session_files.pt:5
-msgid "Quick look (${count} element(s), total size: ${size})"
-msgstr ""
-
-#: ../browser/views.py:178
+#: ../browser/views.py:183
 msgid "No files found to be sent ! Session ${id} not sent."
 msgstr ""
 
-#: ../browser/views.py:164
+#: ../browser/views.py:169
 msgid "No seal code defined in configuration ! Session ${id} not sent."
 msgstr ""
 
-#: ../browser/views.py:171
+#: ../browser/views.py:176
 msgid "No seal email defined in configuration ! Session ${id} not sent."
 msgstr ""
 
-#: ../browser/views.py:123
+#: ../browser/views.py:128
 msgid "No session ID provided!"
 msgstr ""
 
-#: ../browser/views.py:536
+#: ../browser/views.py:541
 msgid "No users selected for CSV download."
 msgstr ""
 
-#: ../browser/views.py:575
+#: ../browser/views.py:580
 msgid "No users selected for email sending."
 msgstr ""
 
-#: ../browser/templates/sessions.pt:44
+#: ../browser/templates/sessions.pt:38
 msgid "Open eSign platform"
 msgstr ""
 
@@ -222,16 +222,20 @@ msgstr ""
 msgid "Parapheo url"
 msgstr ""
 
-#: ../browser/views.py:590
+#: ../browser/views.py:595
 msgid "Portal from email is not configured."
 msgstr ""
 
-#: ../browser/templates/macros.pt:48
+#: ../browser/templates/macros.pt:49
 msgid "Position"
 msgstr ""
 
 #: ../browser/actions.py:71
 msgid "Problem getting signers: \"${error}\")!"
+msgstr ""
+
+#: ../browser/table.py:150
+msgid "Quick look (${count} element(s), total size: ${size}) <span title='${help_title}' class='far fa-question-circle' />"
 msgstr ""
 
 #: ../profiles/default/actions.xml
@@ -254,8 +258,8 @@ msgstr ""
 msgid "Seal email"
 msgstr ""
 
-#: ../browser/table.py:80
-#: ../browser/templates/macros.pt:27
+#: ../browser/table.py:85
+#: ../browser/templates/macros.pt:28
 msgid "Sealed"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "Send Emails"
 msgstr ""
 
-#: ../utils.py:160
+#: ../utils.py:207
 msgid "Session ${id}"
 msgstr ""
 
@@ -283,7 +287,11 @@ msgstr ""
 msgid "Session ID"
 msgstr ""
 
-#: ../browser/views.py:131
+#: ../browser/table.py:139
+msgid "Session can contain max ${max_session_files} elements and have a max size of ${max_session_size} MB."
+msgstr ""
+
+#: ../browser/views.py:136
 msgid "Session deleted successfully!"
 msgstr ""
 
@@ -291,7 +299,7 @@ msgstr ""
 msgid "Session information (${icon_url} Parapheo)"
 msgstr ""
 
-#: ../browser/views.py:133
+#: ../browser/views.py:138
 msgid "Session not found!"
 msgstr ""
 
@@ -299,7 +307,7 @@ msgstr ""
 msgid "Session not yet sent."
 msgstr ""
 
-#: ../browser/views.py:157
+#: ../browser/views.py:162
 msgid "Session with ID ${id} doesn't exist anymore !"
 msgstr ""
 
@@ -315,12 +323,12 @@ msgstr ""
 msgid "Sign url not yet received."
 msgstr ""
 
-#: ../browser/views.py:364
+#: ../browser/views.py:369
 msgid "Signed file download"
 msgstr ""
 
-#: ../browser/table.py:95
-#: ../browser/templates/macros.pt:41
+#: ../browser/table.py:100
+#: ../browser/templates/macros.pt:42
 msgid "Signers"
 msgstr ""
 
@@ -328,24 +336,24 @@ msgstr ""
 msgid "Signing Users: Export CSV"
 msgstr ""
 
-#: ../browser/table.py:50
+#: ../browser/table.py:54
 #: ../browser/templates/macros.pt:11
 msgid "State"
 msgstr ""
 
-#: ../browser/templates/macros.pt:50
+#: ../browser/templates/macros.pt:51
 msgid "Status"
 msgstr ""
 
-#: ../browser/views.py:340
+#: ../browser/views.py:345
 msgid "The corresponding file content cannot be retrieved (${uid}) !"
 msgstr ""
 
-#: ../browser/views.py:320
+#: ../browser/views.py:325
 msgid "The corresponding file identifier cannot be retrieved (${uid}) !"
 msgstr ""
 
-#: ../browser/views.py:332
+#: ../browser/views.py:337
 msgid "The download period for this file has expired (was ${valid_date}) !"
 msgstr ""
 
@@ -381,7 +389,7 @@ msgstr ""
 msgid "The session is ready to be signed in Paraphéo."
 msgstr ""
 
-#: ../browser/views.py:316
+#: ../browser/views.py:321
 msgid "This file identifier is not correct !"
 msgstr ""
 
@@ -397,8 +405,8 @@ msgstr ""
 msgid "This will remove this element or configured sub elements from the relevant esign session"
 msgstr ""
 
-#: ../browser/table.py:66
-#: ../browser/templates/macros.pt:34
+#: ../browser/table.py:71
+#: ../browser/templates/macros.pt:35
 msgid "Title"
 msgstr ""
 
@@ -406,7 +414,7 @@ msgstr ""
 msgid "URL domain where the file can be downloaded."
 msgstr ""
 
-#: ../configure.zcml:34
+#: ../profiles.zcml:22
 msgid "Uninstalls the imio.esign add-on."
 msgstr ""
 
@@ -414,7 +422,7 @@ msgstr ""
 msgid "Used in signers email template."
 msgstr ""
 
-#: ../browser/views.py:599
+#: ../browser/views.py:604
 msgid "User ${userid} has no email address configured. Skipping."
 msgstr ""
 
@@ -446,7 +454,7 @@ msgstr ""
 msgid "VAT number used for esign billing (BE0123456789)."
 msgstr ""
 
-#: ../browser/table.py:210
+#: ../browser/table.py:256
 msgid "View session in dashboard"
 msgstr ""
 
@@ -462,7 +470,7 @@ msgstr ""
 msgid "You are about to send emails to"
 msgstr ""
 
-#: ../browser/views.py:614
+#: ../browser/views.py:619
 msgid "You have been invited to Paraphéo"
 msgstr ""
 
@@ -478,11 +486,11 @@ msgstr ""
 msgid "finalized"
 msgstr ""
 
-#: ../configure.zcml:25
+#: ../profiles.zcml:13
 msgid "imio.esign"
 msgstr ""
 
-#: ../configure.zcml:34
+#: ../profiles.zcml:22
 msgid "imio.esign (uninstall)"
 msgstr ""
 

--- a/src/imio/esign/profiles.zcml
+++ b/src/imio/esign/profiles.zcml
@@ -1,0 +1,29 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="imio.esign">
+
+  <genericsetup:registerProfile
+      name="default"
+      title="imio.esign"
+      directory="profiles/default"
+      description="Installs the imio.esign add-on."
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      post_handler=".setuphandlers.post_install"
+      />
+
+  <genericsetup:registerProfile
+      name="uninstall"
+      title="imio.esign (uninstall)"
+      directory="profiles/uninstall"
+      description="Uninstalls the imio.esign add-on."
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      post_handler=".setuphandlers.uninstall"
+      />
+
+  <utility
+      factory=".setuphandlers.HiddenProfiles"
+      name="imio.esign-hiddenprofiles"
+      />
+
+</configure>

--- a/src/imio/esign/profiles/default/metadata.xml
+++ b/src/imio/esign/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1001</version>
+  <version>1002</version>
   <dependencies>
     <!--<dependency>profile-plone.app.dexterity:default</dependency>-->
     <dependency>profile-plone.restapi:default</dependency>

--- a/src/imio/esign/tests/test_browser_views.py
+++ b/src/imio/esign/tests/test_browser_views.py
@@ -46,7 +46,7 @@ class TestSessionDeleteView(BaseEsignTest):
         self.folder = self.portal["folder0"]
         annex = self.portal["folder0"]["annex0"]
         signers = [("user1", "user1@sign.com", "User 1", "Position 1")]
-        self.session_id, _session = add_files_to_session(signers, (annex.UID(),))
+        self.session_id, _session = add_files_to_session(signers, (annex.UID(),))[-1]
         self.view = SessionDeleteView(self.folder, self.request)
 
     def test_may_delete_session(self):
@@ -91,7 +91,7 @@ class TestExternalSessionCreateView(BaseEsignTest):
         self.folder = self.portal["folder0"]
         annex = self.portal["folder0"]["annex0"]
         signers = [("user1", "user1@sign.com", "User 1", "Position 1")]
-        self.session_id, _session = add_files_to_session(signers, (annex.UID(),))
+        self.session_id, _session = add_files_to_session(signers, (annex.UID(),))[-1]
         self.view = ExternalSessionCreateView(self.folder, self.request)
 
     def test_may_create_external_sessions(self):
@@ -533,7 +533,7 @@ class TestFacetedSessionInfoViewlet(BaseEsignTest):
         self.assertEqual(self._make_viewlet().sessions, {})
 
         # --- valid session id → {session_id: session_info} ---
-        sid, session = add_files_to_session(self.signers, [self.annex.UID()])
+        sid, session = add_files_to_session(self.signers, [self.annex.UID()])[-1]
         self.request.form["esign_session_id[]"] = str(sid)
         sessions = self._make_viewlet().sessions
         self.assertEqual(list(sessions.keys()), [sid])
@@ -559,7 +559,7 @@ class TestFacetedSessionInfoViewlet(BaseEsignTest):
         self.assertIn("<table", result)
 
         # --- c1[] matches (right collection), session selected → index() ---
-        sid, _session = add_files_to_session(self.signers, [self.annex.UID()])
+        sid, _session = add_files_to_session(self.signers, [self.annex.UID()])[-1]
         self.request.form["esign_session_id[]"] = str(sid)
         self.assertEqual(self._make_viewlet().render(), "<rendered/>")
 

--- a/src/imio/esign/tests/test_services.py
+++ b/src/imio/esign/tests/test_services.py
@@ -16,7 +16,7 @@ class TestExternalSessionFeedbackPost(BaseEsignTest):
         self.request.other.pop("BODY", None)
         self.signers = [("user1", "user1@sign.com", "User 1", "Position 1")]
         self.annex = self.portal["folder0"]["annex0"]
-        self.session_id, self.session = add_files_to_session(self.signers, [self.annex.UID()])
+        self.session_id, self.session = add_files_to_session(self.signers, [self.annex.UID()])[-1]
         self.sign_id = self.session["sign_id"]
         self.request._auth = "Bearer test-token"
 
@@ -102,7 +102,7 @@ class TestExternalSessionFeedbackPost(BaseEsignTest):
         self.assertEqual(self.session["sign_url"], "https://sign.example.com/session/1")
 
         # code 22: matching signer email → status 'signed'
-        _, s22 = add_files_to_session(self.signers, [annex1.UID()], discriminators=("c22",))
+        _, s22 = add_files_to_session(self.signers, [annex1.UID()], discriminators=("c22",))[-1]
         self._reply(
             {
                 "app_session_id": s22["sign_id"],
@@ -113,7 +113,7 @@ class TestExternalSessionFeedbackPost(BaseEsignTest):
         self.assertEqual(s22["signers"][0]["status"], "signed")
 
         # code 22: signer already 'refused' is not updated
-        _, s22b = add_files_to_session(self.signers, [annex1.UID()], discriminators=("c22b",))
+        _, s22b = add_files_to_session(self.signers, [annex1.UID()], discriminators=("c22b",))[-1]
         s22b["signers"][0]["status"] = "refused"
         self._reply(
             {
@@ -125,12 +125,12 @@ class TestExternalSessionFeedbackPost(BaseEsignTest):
         self.assertEqual(s22b["signers"][0]["status"], "refused")
 
         # code 23: state → 'returned'
-        _, s23 = add_files_to_session(self.signers, [annex1.UID()], discriminators=("c23",))
+        _, s23 = add_files_to_session(self.signers, [annex1.UID()], discriminators=("c23",))[-1]
         self._reply({"app_session_id": s23["sign_id"], "code": 23})
         self.assertEqual(s23["state"], "returned")
 
         # code 52: state → 'refused'; matching signer → 'refused'
-        _, s52 = add_files_to_session(self.signers, [annex1.UID()], discriminators=("c52",))
+        _, s52 = add_files_to_session(self.signers, [annex1.UID()], discriminators=("c52",))[-1]
         self._reply(
             {
                 "app_session_id": s52["sign_id"],
@@ -142,18 +142,18 @@ class TestExternalSessionFeedbackPost(BaseEsignTest):
         self.assertEqual(s52["signers"][0]["status"], "refused")
 
         # code 53: state → 'signed' (documents signed but not returned)
-        _, s53 = add_files_to_session(self.signers, [annex1.UID()], discriminators=("c53",))
+        _, s53 = add_files_to_session(self.signers, [annex1.UID()], discriminators=("c53",))[-1]
         self._reply({"app_session_id": s53["sign_id"], "code": 53})
         self.assertEqual(s53["state"], "signed")
 
         # error codes: state → 'errored'
         for code in (50, 51, 54, 55, 56, 57, 58, 59):
-            _, serr = add_files_to_session(self.signers, [annex1.UID()], discriminators=(str(code),))
+            _, serr = add_files_to_session(self.signers, [annex1.UID()], discriminators=(str(code),))[-1]
             self._reply({"app_session_id": serr["sign_id"], "code": code})
             self.assertEqual(serr["state"], "errored")
 
         # returns: entry structure (code, db_state, value, message, datetime)
-        _, srtn = add_files_to_session(self.signers, [annex1.UID()], discriminators=("rtn",))
+        _, srtn = add_files_to_session(self.signers, [annex1.UID()], discriminators=("rtn",))[-1]
         self._reply(
             {
                 "app_session_id": srtn["sign_id"],

--- a/src/imio/esign/tests/test_utils.py
+++ b/src/imio/esign/tests/test_utils.py
@@ -271,26 +271,26 @@ class TestUtils(BaseEsignTest):
         sessions = annot["sessions"]
         self.assertEqual(len(sessions), 3)
         self.assertEqual([len(sessions[i]["files"]) for i in (0, 1, 2)], [2, 2, 1])
-        self.assertEqual(sessions[0]["state"], "complete")
-        self.assertEqual(sessions[1]["state"], "complete")
+        self.assertEqual(sessions[0]["state"], "draft_full")
+        self.assertEqual(sessions[1]["state"], "draft_full")
         self.assertEqual(sessions[2]["state"], "draft")
         # return value is for the last file added
         self.assertEqual(sid, 2)
         self.assertIs(session, sessions[2])
 
-        # --- a session marked 'complete' is never reused, even if the limit is later raised ---
+        # --- a session marked 'draft_full' is never reused, even if the limit is later raised ---
         del root_annot["imio.esign"]
         set_esign_registry_max_session_files(2)
         # First batch: 3 files → session 0 gets 2 (and is closed), session 1 gets 1 (draft)
         add_files_to_session(signers, tuple(self.uids[:3]))
         annot = get_session_annotation()
-        self.assertEqual(annot["sessions"][0]["state"], "complete")
+        self.assertEqual(annot["sessions"][0]["state"], "draft_full")
         self.assertEqual(annot["sessions"][1]["state"], "draft")
         # Raise the max back to a value that would mathematically allow reusing session 0
         set_esign_registry_max_session_files(10)
         sid, session = add_files_to_session(signers, (self.uids[3],))[-1]
-        # Session 0 stays complete; new file lands in the existing draft (session 1), not in 0
-        self.assertEqual(annot["sessions"][0]["state"], "complete")
+        # Session 0 stays draft_full; new file lands in the existing draft (session 1), not in 0
+        self.assertEqual(annot["sessions"][0]["state"], "draft_full")
         self.assertEqual(sid, 1)
         self.assertEqual(len(annot["sessions"][1]["files"]), 2)
 

--- a/src/imio/esign/tests/test_utils.py
+++ b/src/imio/esign/tests/test_utils.py
@@ -3,8 +3,10 @@
 from collections import OrderedDict
 from datetime import date
 from datetime import timedelta
+from imio.esign.config import get_esign_registry_max_session_files
 from imio.esign.config import get_esign_registry_max_session_size
 from imio.esign.config import set_esign_registry_external_watchers
+from imio.esign.config import set_esign_registry_max_session_files
 from imio.esign.config import set_esign_registry_max_session_size
 from imio.esign.tests.base import BaseEsignTest
 from imio.esign.utils import add_files_to_session
@@ -44,7 +46,8 @@ class TestUtils(BaseEsignTest):
 
     def test_add_files_to_session(self):
         """add_files_to_session: session creation, discrimination, reuse, size splitting,
-        duplicate filenames, and idempotent metadata update."""
+        count splitting, completed sessions not reused, duplicate filenames, and idempotent
+        metadata update."""
         root_annot = IAnnotations(self.portal)
         self.assertNotIn("imio.esign", root_annot)
         signers = [
@@ -53,7 +56,8 @@ class TestUtils(BaseEsignTest):
         ]
 
         # --- create first session ---
-        sid, session = add_files_to_session(signers, (self.uids[0],), title="my title", watchers=("stalker@sign.com",))
+        sid, session = add_files_to_session(signers, (self.uids[0],), title="my title",
+                                            watchers=("stalker@sign.com",))[-1]
         self.assertEqual(sid, 0)
         annot = root_annot["imio.esign"]
         self.assertEqual(annot["numbering"], 1)
@@ -89,7 +93,7 @@ class TestUtils(BaseEsignTest):
         signers[1] = ("user2", "user2@sign.com", "User 2", "Position 2b")  # position change is non-discriminant
         annex1_obj = uuidToObject(uuid=self.uids[1], unrestricted=True)
         annex1_obj.file.filename = u"annex0.pdf"
-        sid, session = add_files_to_session(signers, (self.uids[1],))
+        sid, session = add_files_to_session(signers, (self.uids[1],))[-1]
         self.assertEqual(sid, 0)
         self.assertEqual(annot["numbering"], 1)
         self.assertEqual(len(annot["sessions"]), 1)
@@ -103,7 +107,7 @@ class TestUtils(BaseEsignTest):
         self.assertEqual(session["size"], 6968 + 7014)  # annex1 + annex2
 
         # --- new discriminator → new session ---
-        sid, session = add_files_to_session(signers, (self.uids[2],), discriminators=("council1",))
+        sid, session = add_files_to_session(signers, (self.uids[2],), discriminators=("council1",))[-1]
         self.assertEqual(sid, 1)
         self.assertEqual(annot["numbering"], 2)
         self.assertEqual(len(annot["sessions"]), 2)
@@ -113,7 +117,7 @@ class TestUtils(BaseEsignTest):
         self.assertEqual(len(session["watchers"]), 0)
 
         # --- same discriminator → reuse session ---
-        sid, session = add_files_to_session(signers, (self.uids[3],), discriminators=("council1",))
+        sid, session = add_files_to_session(signers, (self.uids[3],), discriminators=("council1",))[-1]
         self.assertEqual(sid, 1)
         self.assertEqual(annot["numbering"], 2)
         self.assertEqual(len(annot["sessions"]), 2)
@@ -122,27 +126,27 @@ class TestUtils(BaseEsignTest):
         self.assertEqual(len(session["files"]), 2)
 
         # --- different discriminator → new session ---
-        sid, _session = add_files_to_session(signers, (self.uids[4],), discriminators=("council2",))
+        sid, _session = add_files_to_session(signers, (self.uids[4],), discriminators=("council2",))[-1]
         self.assertEqual(sid, 2)
 
         # --- explicit session_id overrides discrimination ---
-        sid, _session = add_files_to_session(signers, (self.uids[5],), session_id=0, discriminators=("council3",))
+        sid, _session = add_files_to_session(signers, (self.uids[5],), session_id=0, discriminators=("council3",))[-1]
         self.assertEqual(sid, 0)
 
         # --- unfound session_id → new session ---
-        sid, _session = add_files_to_session(signers, (self.uids[6],), session_id=999, discriminators=("council3",))
+        sid, _session = add_files_to_session(signers, (self.uids[6],), session_id=999, discriminators=("council3",))[-1]
         self.assertEqual(sid, 3)
 
         # --- different signers → new session ---
-        sid, _session = add_files_to_session([signers[0]], (self.uids[7],))
+        sid, _session = add_files_to_session([signers[0]], (self.uids[7],))[-1]
         self.assertEqual(sid, 4)
 
         # --- different seal → new session ---
-        sid, _session = add_files_to_session(signers, (self.uids[8],), seal="seal1")
+        sid, _session = add_files_to_session(signers, (self.uids[8],), seal="seal1")[-1]
         self.assertEqual(sid, 5)
 
         # --- different acroform → new session ---
-        sid, _session = add_files_to_session(signers, (self.uids[9],), acroform=False)
+        sid, _session = add_files_to_session(signers, (self.uids[9],), acroform=False)[-1]
         self.assertEqual(sid, 6)
         self.assertEqual(len(annot["uids"]), 10)
         self.assertEqual(len(annot["c_uids"]), 2)
@@ -151,7 +155,7 @@ class TestUtils(BaseEsignTest):
         self.assertEqual(len(annot["sessions"]), 7)
 
         # --- no signers → new session ---
-        sid, session = add_files_to_session([], (self.uids[10],), seal="seal2")
+        sid, session = add_files_to_session([], (self.uids[10],), seal="seal2")[-1]
         self.assertEqual(sid, 7)
         self.assertEqual(len(annot["sessions"]), 8)
         self.assertEqual(session["signers"], [])
@@ -159,7 +163,7 @@ class TestUtils(BaseEsignTest):
 
         # --- same seal but session already sent → new session ---
         session["state"] = "sent"
-        sid, _session = add_files_to_session([], (self.uids[11],), seal="seal2")
+        sid, _session = add_files_to_session([], (self.uids[11],), seal="seal2")[-1]
         self.assertEqual(sid, 8)
         self.assertEqual(len(annot["sessions"]), 9)
 
@@ -167,13 +171,13 @@ class TestUtils(BaseEsignTest):
         del root_annot["imio.esign"]
         for i in range(3):
             api.content.get(UID=self.uids[i]).file.filename = u"same_filename.pdf"
-        s, ses = add_files_to_session(signers, (self.uids[0],))
+        s, ses = add_files_to_session(signers, (self.uids[0],))[-1]
         self.assertEqual(len(ses["files"]), 1)
         self.assertEqual(ses["files"][0]["filename"], "same_filename.pdf")
-        s, ses = add_files_to_session(signers, (self.uids[1],), session_id=s)
+        s, ses = add_files_to_session(signers, (self.uids[1],), session_id=s)[-1]
         self.assertEqual(len(ses["files"]), 2)
         self.assertIn("same_filename-1.pdf", [f["filename"] for f in ses["files"]])
-        s, ses = add_files_to_session(signers, (self.uids[2],), session_id=s)
+        s, ses = add_files_to_session(signers, (self.uids[2],), session_id=s)[-1]
         self.assertEqual(len(ses["files"]), 3)
         filenames = [f["filename"] for f in ses["files"]]
         self.assertIn("same_filename.pdf", filenames)
@@ -188,7 +192,7 @@ class TestUtils(BaseEsignTest):
         # reset annex1 filename which was changed in the duplicate-filename block above
         annex1_reset = api.content.get(UID=self.uids[1])
         annex1_reset.file.filename = u"annex1.pdf"
-        sid, ses = add_files_to_session(signers, (annex0_uid,))
+        sid, ses = add_files_to_session(signers, (annex0_uid,))[-1]
         self.assertEqual(sid, 0)
         self.assertEqual(len(ses["files"]), 1)
         self.assertEqual(ses["files"][0]["filename"], "annex0.pdf")
@@ -196,13 +200,13 @@ class TestUtils(BaseEsignTest):
         self.assertEqual(ses["size"], 6968)
         annex0.file.filename = u"new_annex0.pdf"
         annex0.setTitle("New Annex 0")
-        sid, ses = add_files_to_session(signers, (annex0_uid,))
+        sid, ses = add_files_to_session(signers, (annex0_uid,))[-1]
         self.assertEqual(sid, 0)
         self.assertEqual(len(ses["files"]), 1)
         self.assertEqual(ses["files"][0]["filename"], "new_annex0.pdf")
         self.assertEqual(ses["files"][0]["title"], "New Annex 0")
         self.assertEqual(ses["size"], 6968)
-        sid, ses = add_files_to_session(signers, (annex0_uid,))
+        sid, ses = add_files_to_session(signers, (annex0_uid,))[-1]
         self.assertEqual(sid, 0)
         self.assertEqual(len(ses["files"]), 1)
         self.assertEqual(ses["files"][0]["filename"], "new_annex0.pdf")
@@ -210,7 +214,7 @@ class TestUtils(BaseEsignTest):
         self.assertEqual(ses["size"], 6968)
         annex1_uid = self.uids[1]
         annex1 = api.content.get(UID=annex1_uid)
-        sid, ses = add_files_to_session(signers, (annex1_uid,))
+        sid, ses = add_files_to_session(signers, (annex1_uid,))[-1]
         self.assertEqual(sid, 0)
         self.assertEqual(len(ses["files"]), 2)
         self.assertEqual(ses["files"][1]["filename"], "annex1.pdf")
@@ -240,21 +244,55 @@ class TestUtils(BaseEsignTest):
         # --- size-based session splitting ---
         del root_annot["imio.esign"]
         annex0.file.filename = u"annex0.pdf"
-        sid0, ses0 = add_files_to_session(signers, (annex0_uid,))
+        sid0, ses0 = add_files_to_session(signers, (annex0_uid,))[-1]
         self.assertEqual(sid0, 0)
         self.assertEqual(ses0["size"], 6968)
         ses0["size"] = 1 * 1024 ** 2 - 1
         prev_max = get_esign_registry_max_session_size()
         self.addCleanup(set_esign_registry_max_session_size, prev_max)
         set_esign_registry_max_session_size(1)
-        sid1, ses1 = add_files_to_session(signers, (self.uids[1],))
+        sid1, ses1 = add_files_to_session(signers, (self.uids[1],))[-1]
         self.assertEqual(sid1, 1)
         self.assertIsNot(ses1, ses0)
         self.assertEqual(ses1["size"], 6968)
-        sid2, ses2 = add_files_to_session(signers, (self.uids[2],))
+        sid2, ses2 = add_files_to_session(signers, (self.uids[2],))[-1]
         self.assertEqual(sid2, 1)
         self.assertIs(ses2, ses1)
         self.assertEqual(ses2["size"], 6968 + 6968)
+
+        # --- count-based session splitting: a single batch dispatched across several sessions ---
+        del root_annot["imio.esign"]
+        prev_max_files = get_esign_registry_max_session_files()
+        self.addCleanup(set_esign_registry_max_session_files, prev_max_files)
+        set_esign_registry_max_session_files(2)
+        signers = [("user1", "user1@sign.com", "User 1", "P1")]
+        sid, session = add_files_to_session(signers, tuple(self.uids[:5]))[-1]
+        annot = get_session_annotation()
+        sessions = annot["sessions"]
+        self.assertEqual(len(sessions), 3)
+        self.assertEqual([len(sessions[i]["files"]) for i in (0, 1, 2)], [2, 2, 1])
+        self.assertEqual(sessions[0]["state"], "complete")
+        self.assertEqual(sessions[1]["state"], "complete")
+        self.assertEqual(sessions[2]["state"], "draft")
+        # return value is for the last file added
+        self.assertEqual(sid, 2)
+        self.assertIs(session, sessions[2])
+
+        # --- a session marked 'complete' is never reused, even if the limit is later raised ---
+        del root_annot["imio.esign"]
+        set_esign_registry_max_session_files(2)
+        # First batch: 3 files → session 0 gets 2 (and is closed), session 1 gets 1 (draft)
+        add_files_to_session(signers, tuple(self.uids[:3]))
+        annot = get_session_annotation()
+        self.assertEqual(annot["sessions"][0]["state"], "complete")
+        self.assertEqual(annot["sessions"][1]["state"], "draft")
+        # Raise the max back to a value that would mathematically allow reusing session 0
+        set_esign_registry_max_session_files(10)
+        sid, session = add_files_to_session(signers, (self.uids[3],))[-1]
+        # Session 0 stays complete; new file lands in the existing draft (session 1), not in 0
+        self.assertEqual(annot["sessions"][0]["state"], "complete")
+        self.assertEqual(sid, 1)
+        self.assertEqual(len(annot["sessions"][1]["files"]), 2)
 
     def test_add_files_ordering_by_context(self):
         """add_files_to_session: files are ordered by their sibling position within their context."""
@@ -270,25 +308,25 @@ class TestUtils(BaseEsignTest):
         # Case 1: uid[0] then uid[1] (different context) then uid[2] (same context as uid[0])
         # uid[2] must land immediately after uid[0], not after uid[1]
         reset_annotation()
-        sid, session = add_files_to_session(signers, (self.uids[0],))
-        sid, session = add_files_to_session(signers, (self.uids[1],), session_id=sid)
-        sid, session = add_files_to_session(signers, (self.uids[2],), session_id=sid)
+        sid, session = add_files_to_session(signers, (self.uids[0],))[-1]
+        sid, session = add_files_to_session(signers, (self.uids[1],), session_id=sid)[-1]
+        sid, session = add_files_to_session(signers, (self.uids[2],), session_id=sid)[-1]
         self.assertEqual([f["uid"] for f in session["files"]], [self.uids[0], self.uids[2], self.uids[1]])
 
         # Case 2: uid[4] (3rd in folder0) added before uid[0] (1st in folder0)
         # uid[0] must land before uid[4]
         reset_annotation()
-        sid, session = add_files_to_session(signers, (self.uids[4],))
-        sid, session = add_files_to_session(signers, (self.uids[0],), session_id=sid)
+        sid, session = add_files_to_session(signers, (self.uids[4],))[-1]
+        sid, session = add_files_to_session(signers, (self.uids[0],), session_id=sid)[-1]
         self.assertEqual([f["uid"] for f in session["files"]], [self.uids[0], self.uids[4]])
 
         # Case 3: uid[0], uid[4] in session, then uid[1] (different context), then uid[2]
         # uid[2] must be inserted between uid[0] and uid[4]
         reset_annotation()
-        sid, session = add_files_to_session(signers, (self.uids[0],))
-        sid, session = add_files_to_session(signers, (self.uids[4],), session_id=sid)
-        sid, session = add_files_to_session(signers, (self.uids[1],), session_id=sid)
-        sid, session = add_files_to_session(signers, (self.uids[2],), session_id=sid)
+        sid, session = add_files_to_session(signers, (self.uids[0],))[-1]
+        sid, session = add_files_to_session(signers, (self.uids[4],), session_id=sid)[-1]
+        sid, session = add_files_to_session(signers, (self.uids[1],), session_id=sid)[-1]
+        sid, session = add_files_to_session(signers, (self.uids[2],), session_id=sid)[-1]
         self.assertEqual(
             [f["uid"] for f in session["files"]],
             [self.uids[0], self.uids[2], self.uids[4], self.uids[1]],
@@ -377,7 +415,7 @@ class TestUtils(BaseEsignTest):
         annot = get_session_annotation()
         self.assertEqual(len(annot["sessions"]), 0)
         add_files_to_session(signers, (self.uids[0], self.uids[1]))
-        sid2, _session = add_files_to_session(signers, (self.uids[2], self.uids[3]), seal="seal1")
+        sid2, _session = add_files_to_session(signers, (self.uids[2], self.uids[3]), seal="seal1")[-1]
         self.assertEqual(sid2, 1)
         remove_session(0)
         self.assertEqual(len(annot["uids"]), 2)
@@ -395,7 +433,7 @@ class TestUtils(BaseEsignTest):
             ("user1", "user1@sign.com", "User 1", "Position 1"),
             ("user2", "user2@sign.com", "User 2", "Position 2"),
         ]
-        sid, session = add_files_to_session(signers, (self.uids[0], self.uids[1]))
+        sid, session = add_files_to_session(signers, (self.uids[0], self.uids[1]))[-1]
         self.assertEqual(get_session_info(sid), session)
 
     def test_get_sessions_for(self):
@@ -483,7 +521,7 @@ class TestUtils(BaseEsignTest):
         self.assertEqual(result, "_session_not_found_")
 
         # --- seal session: email missing ---
-        sid, _session = add_files_to_session([], (self.uids[0],), seal="SEAL")
+        sid, _session = add_files_to_session([], (self.uids[0],), seal="SEAL")[-1]
         result = create_external_session(sid, esign_root_url="http://test.example.com")
         self.assertEqual(result, "_no_seal_email_")
 
@@ -494,7 +532,7 @@ class TestUtils(BaseEsignTest):
         self.assertEqual(result, "_no_seal_code_")
 
         # --- error response: state unchanged ---
-        sid2, session2 = add_files_to_session(signers, (self.uids[1],))
+        sid2, session2 = add_files_to_session(signers, (self.uids[1],))[-1]
         mock_response = Mock()
         mock_response.status_code = 500
         mock_response.text = "Internal Server Error"
@@ -505,7 +543,7 @@ class TestUtils(BaseEsignTest):
         self.assertEqual(session2["state"], "draft")
 
         # --- sign payload: correct structure, state set to 'sent' ---
-        sid3, session3 = add_files_to_session(signers, (self.uids[2],))
+        sid3, session3 = add_files_to_session(signers, (self.uids[2],))[-1]
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = '{"message": "OK"}'
@@ -547,7 +585,7 @@ class TestUtils(BaseEsignTest):
         # --- seal-only payload ---
         api.portal.set_registry_record("imio.esign.seal_code", u"PADES_SEAL")
         self.addCleanup(api.portal.set_registry_record, "imio.esign.seal_code", u"")
-        sid4, _session = add_files_to_session([], (self.uids[3],), seal="SEAL")
+        sid4, _session = add_files_to_session([], (self.uids[3],), seal="SEAL")[-1]
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = '{"message": "OK"}'
@@ -591,7 +629,7 @@ class TestUtils(BaseEsignTest):
         self.assertEqual([f[1][0] for f in posted_files], [u"annex0.pdf", u"annex3.pdf"])
 
         # --- combined sign + seal payload ---
-        sid5, _session = add_files_to_session(signers, (self.uids[4],), seal="SEAL")
+        sid5, _session = add_files_to_session(signers, (self.uids[4],), seal="SEAL")[-1]
         set_esign_registry_external_watchers(u"example@imlo.be")
         self.addCleanup(set_esign_registry_external_watchers, u"")
         mock_response = Mock()
@@ -636,7 +674,7 @@ class TestUtils(BaseEsignTest):
         self.assertEqual([f[1][0] for f in posted_files], [u"annex4.pdf"])
 
         # --- no resolvable files: returns _no_files_, no HTTP call made ---
-        sid6, session6 = add_files_to_session(signers, (self.uids[5],))
+        sid6, session6 = add_files_to_session(signers, (self.uids[5],))[-1]
         for i in range(len(session6["files"])):
             session6["files"][i]["uid"] = "nonexistent_uid_{}".format(i)
         with patch("imio.esign.utils.get_auth_token", return_value="test-token"):  # remote OAuth

--- a/src/imio/esign/upgrades.zcml
+++ b/src/imio/esign/upgrades.zcml
@@ -1,0 +1,30 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="imio.esign">
+
+  <genericsetup:upgradeSteps
+      profile="imio.esign:default"
+      source="1000"
+      destination="1001"
+      >
+    <genericsetup:upgradeDepends
+        title="Apply rolemap"
+        description=""
+        import_steps="rolemap"
+        />
+  </genericsetup:upgradeSteps>
+
+  <genericsetup:upgradeSteps
+      profile="imio.esign:default"
+      source="1001"
+      destination="1002"
+      >
+    <genericsetup:upgradeDepends
+        title="Apply registry for new field"
+        description=""
+        import_steps="plone.app.registry"
+        />
+  </genericsetup:upgradeSteps>
+
+</configure>

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -383,11 +383,13 @@ def discriminate_sessions(signers, seal, acroform, discriminators=(), annot=None
             continue
         session_size = session.get("size", 0)
         session_files_count = len(session.get("files", []))
-        if session_files_count + files_count > max_session_files or size + session_size > max_session_size:
-            # Session can't accept this batch. Mark it complete, so it will never be reconsidered for any future batch.
+        if session_files_count + files_count >= max_session_files or size + session_size >= max_session_size:
+            #  Mark it complete, so it will never be reconsidered for any future batch.
             session["state"] = "complete"
             session["last_update"] = datetime.now()
-            continue
+            if session_files_count + files_count > max_session_files or size + session_size > max_session_size:
+                # Session can't accept this batch.
+                continue
 
         return session_id, session
 

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -64,7 +64,7 @@ def add_files_to_session(  # noqa C901
 
     Files are dispatched one by one. When the current target session would exceed
     ``max_session_size`` or ``max_session_files`` by adding the next file, it is
-    marked as ``complete`` (so it will never be reused) and a new session is
+    marked as ``draft_full`` (so it will never be reused) and a new session is
     discriminated or created for the remaining files.
 
     :param signers: a list of signers, each is a quartet with userid, email, fullname and position text
@@ -384,8 +384,8 @@ def discriminate_sessions(signers, seal, acroform, discriminators=(), annot=None
         session_size = session.get("size", 0)
         session_files_count = len(session.get("files", []))
         if session_files_count + files_count >= max_session_files or size + session_size >= max_session_size:
-            #  Mark it complete, so it will never be reconsidered for any future batch.
-            session["state"] = "complete"
+            #  Mark it draft_full, so it will never be reconsidered for any future batch.
+            session["state"] = "draft_full"
             session["last_update"] = datetime.now()
             if session_files_count + files_count > max_session_files or size + session_size > max_session_size:
                 # Session can't accept this batch.
@@ -596,9 +596,9 @@ def get_state_description(state):
     """
     Get a human readable description for a given session state.
 
-                  ┌─────────┐  (full)  ┌──────────┐
-                  │  draft  │─────────▶│ complete │
-                  └────┬────┘          └─────┬────┘
+                  ┌─────────┐  (full)  ┌────────────┐
+                  │  draft  │─────────▶│ draft_full │
+                  └────┬────┘          └─────┬──────┘
                        │                     │
              (sent to Paraphéo)     (sent to Paraphéo)
                        │                     │
@@ -635,7 +635,7 @@ def get_state_description(state):
     """
     return {
         "draft": u"The session is getting ready to be sent to Paraphéo by a signing manager.",
-        "complete": u"The session is full (max size or max files reached) and will not accept any more batches; "
+        "draft_full": u"The session is full (max size or max files reached) and will not accept any more batches; "
         u"it is awaiting being sent to Paraphéo.",
         "sent": u"The session has been sent to Paraphéo.",
         "errored": u"The session encountered an error during its processing.",

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -50,8 +50,15 @@ def get_filesize(uid):
 
 
 def add_files_to_session(  # noqa C901
-    signers, files_uids, seal=None, acroform=True, session_id=None, title="", discriminators=(), watchers=(),
-    create_session_custom_data=None
+    signers,
+    files_uids,
+    seal=None,
+    acroform=True,
+    session_id=None,
+    title="",
+    discriminators=(),
+    watchers=(),
+    create_session_custom_data=None,
 ):
     """Add files to a session with the given signers.
 
@@ -88,38 +95,47 @@ def add_files_to_session(  # noqa C901
 
         if dispatch:
             session_id, session = discriminate_sessions(
-                signers, seal, acroform, discriminators=discriminators, size=file_size, files_count=1,
+                signers,
+                seal,
+                acroform,
+                discriminators=discriminators,
+                size=file_size,
+                files_count=1,
             )
             if not session:
                 session_id, session = create_session(
-                    signers, seal, acroform=acroform, title=title, annot=annot,
-                    discriminators=discriminators, watchers=watchers,
+                    signers,
+                    seal,
+                    acroform=acroform,
+                    title=title,
+                    annot=annot,
+                    discriminators=discriminators,
+                    watchers=watchers,
                     create_session_custom_data=create_session_custom_data,
                 )
-                audit(
-                    "create_session",
-                    "session={} signers={}".format(session_id, "|".join([sg[1] for sg in signers]))
-                )
+                audit("create_session", "session={} signers={}".format(session_id, "|".join([sg[1] for sg in signers])))
 
         annex = uuidToObject(uuid=uid, unrestricted=True)
         context_uid_provider = getAdapter(annex, IContextUidProvider)
         context_uid = context_uid_provider.get_context_uid()
         # update data if adding same file to same session
-        if annot['uids'].get(uid, -1) == session_id:
-            logger.info('File with UID %s is already in session_id %s and data were updated!', uid, session_id)
+        if annot["uids"].get(uid, -1) == session_id:
+            logger.info("File with UID %s is already in session_id %s and data were updated!", uid, session_id)
             remove_files_from_session([uid], remove_empty_session=False)
 
         existing_files = [path.splitext(f["filename"])[0] for f in session["files"]]
         filename, ext = path.splitext(annex.file.filename or "no_filename.pdf")
         new_filename = get_correct_id(existing_files, filename)
-        file_dict = PersistentMapping({
-            "scan_id": annex.scan_id,
-            "filename": new_filename + ext,
-            "title": annex.title or "no_title",
-            "uid": uid,
-            "context_uid": context_uid,
-            "status": "",
-        })
+        file_dict = PersistentMapping(
+            {
+                "scan_id": annex.scan_id,
+                "filename": new_filename + ext,
+                "title": annex.title or "no_title",
+                "uid": uid,
+                "context_uid": context_uid,
+                "status": "",
+            }
+        )
         # Find the range of files already belonging to this context (if any)
         context_start_idx, context_end_idx = None, None
         for i, f in enumerate(session["files"]):
@@ -139,18 +155,15 @@ def add_files_to_session(  # noqa C901
                 uid_order = {a.UID(): idx for idx, a in enumerate(context.values())}
             else:
                 uid_order = {}
-            files = session["files"][context_start_idx:context_end_idx + 1]
+            files = session["files"][context_start_idx : context_end_idx + 1]
             files.append(file_dict)
-            session["files"][context_start_idx:context_end_idx + 1] = sorted(
+            session["files"][context_start_idx : context_end_idx + 1] = sorted(
                 files, key=lambda f: uid_order.get(f["uid"], -1)
             )
         session["size"] = session.get("size", 0) + file_size
         annot["uids"][uid] = session_id
         annot["c_uids"].setdefault(context_uid, PersistentList()).append(uid)
-        audit(
-            "add_files_to_session",
-            "session={} context={} file={}".format(session_id, context_uid, uid)
-        )
+        audit("add_files_to_session", "session={} context={} file={}".format(session_id, context_uid, uid))
         if session["client_id"] is None:
             # FIXME what if scan_id is None ?
             session["client_id"] = session["files"][0]["scan_id"][0:7]
@@ -195,9 +208,14 @@ def create_external_session(session_id, esign_root_url=None):
     data_payload = {
         "commonData": {
             "endpointUrl": portal.absolute_url() + "/@external_session_feedback",
-            "documentData": [{"filename": filename, "uniqueCode": "{}__{}".format(unique_code, fuid),
-                              "docUuid": get_suid_from_uuid(fuid)}
-                             for unique_code, filename, z, fuid in files],
+            "documentData": [
+                {
+                    "filename": filename,
+                    "uniqueCode": "{}__{}".format(unique_code, fuid),
+                    "docUuid": get_suid_from_uuid(fuid),
+                }
+                for unique_code, filename, z, fuid in files
+            ],
             "imioAppSessionId": session["sign_id"],
             "sessionName": session["title"],
         }
@@ -270,8 +288,16 @@ def create_external_session(session_id, esign_root_url=None):
     return ret
 
 
-def create_session(signers, seal=False, acroform=True, title=None, annot=None, discriminators=(), watchers=(),
-                   create_session_custom_data=None):
+def create_session(
+    signers,
+    seal=False,
+    acroform=True,
+    title=None,
+    annot=None,
+    discriminators=(),
+    watchers=(),
+    create_session_custom_data=None,
+):
     """Create a session with the given signers and seal.
 
     :param signers: a list of signers, each is a quartet with userid, email, fullname and position text
@@ -290,27 +316,30 @@ def create_session(signers, seal=False, acroform=True, title=None, annot=None, d
     session_id = annot["numbering"]
     annot["numbering"] += 1
 
-    sessions[session_id] = PersistentMapping({
-        "acroform": acroform,
-        "client_id": None,
-        "discriminators": discriminators,
-        "files": PersistentList(),
-        "last_update": datetime.now(),
-        "seal": seal,
-        "sign_id": None,
-        "sign_url": None,
-        "signers": PersistentList(
-            [
-                PersistentMapping({"userid": userid, "email": email, "fullname": fullname, "position": position,
-                                   "status": ""})
-                for userid, email, fullname, position in signers
-            ]
-        ),
-        "watchers": PersistentList(watchers),
-        "state": "draft",
-        "title": title,
-        "returns": PersistentList(),
-    })
+    sessions[session_id] = PersistentMapping(
+        {
+            "acroform": acroform,
+            "client_id": None,
+            "discriminators": discriminators,
+            "files": PersistentList(),
+            "last_update": datetime.now(),
+            "seal": seal,
+            "sign_id": None,
+            "sign_url": None,
+            "signers": PersistentList(
+                [
+                    PersistentMapping(
+                        {"userid": userid, "email": email, "fullname": fullname, "position": position, "status": ""}
+                    )
+                    for userid, email, fullname, position in signers
+                ]
+            ),
+            "watchers": PersistentList(watchers),
+            "state": "draft",
+            "title": title,
+            "returns": PersistentList(),
+        }
+    )
     if create_session_custom_data:
         for k, v in create_session_custom_data.items():
             sessions[session_id][k] = v
@@ -332,7 +361,7 @@ def discriminate_sessions(signers, seal, acroform, discriminators=(), annot=None
     if not annot:
         annot = get_session_annotation()
     sessions = annot.get("sessions", {})
-    max_session_size = get_esign_registry_max_session_size() * 1024**2
+    max_session_size = get_esign_registry_max_session_size() * 1024 ** 2
     max_session_files = get_esign_registry_max_session_files()
 
     for session_id, session in sessions.items():
@@ -400,8 +429,8 @@ def get_file_info(session_id, file_uid, portal=None, readonly=True):
     """
     session = get_session_info(session_id, portal=portal, readonly=readonly)
     if session:
-        for file_info in session['files']:
-            if file_info['uid'] == file_uid:
+        for file_info in session["files"]:
+            if file_info["uid"] == file_uid:
                 if readonly:
                     file_info = deepcopy(file_info)
                 return file_info
@@ -416,8 +445,8 @@ def get_session_info(session_id, portal=None, readonly=True):
     """
     annot = get_session_annotation(portal=portal)
     session = {}
-    if session_id in annot['sessions']:
-        session = annot['sessions'][session_id]
+    if session_id in annot["sessions"]:
+        session = annot["sessions"][session_id]
         if readonly:
             session = deepcopy(session)
     return session
@@ -527,7 +556,7 @@ def get_file_download_url(uid, root_url=None, short_uid=None):
         raise Exception("No root URL provided for file download url.")
     if not short_uid:
         short_uid = get_suid_from_uuid(uid)
-    return "{}/{}".format(root_url.strip('/'), short_uid), short_uid
+    return "{}/{}".format(root_url.strip("/"), short_uid), short_uid
 
 
 def get_max_download_date(obj, delta=timedelta(days=90), adate=None):
@@ -565,51 +594,54 @@ def get_state_description(state):
     """
     Get a human readable description for a given session state.
 
-                       ┌─────────┐
-                       │  draft  │
-                       └────┬────┘
-                            │
-                 (session sent to Paraphéo)
-                            │
-                            ▼
-                       ┌─────────┐
-             ┌─────────│  sent   │─────────┐
-             │         └────┬────┘         │
-             │              │              │
-    (error occurred)     (ready)   (signer refused)
-             │              │              │
-             ▼              ▼              ▼
-        ┌─────────┐    ┌─────────┐    ┌─────────┐
-        │ errored │    │ to_sign │    │ refused │
-        └─────────┘    └────┬────┘    └─────────┘
-                            │
-                   (documents signed)
-                            │
-                            ├──────────────┐
-                            │              │
-            (sent back successfully)  (send back failed)
-                            │              │
-                            ▼              │
-                      ┌──────────┐         │
-                      │ returned │         │
-                      └─────┬────┘         │
-                            │              │
-                 (documents received)      │
-                            │              │
-                            ▼              ▼
-                      ┌───────────┐   ┌─────────┐
-                      │ finalized │   │ signed  │
-                      └───────────┘   └─────────┘
+                  ┌─────────┐  (full)  ┌──────────┐
+                  │  draft  │─────────▶│ complete │
+                  └────┬────┘          └─────┬────┘
+                       │                     │
+             (sent to Paraphéo)     (sent to Paraphéo)
+                       │                     │
+                       └──────────┬──────────┘
+                                  ▼
+                             ┌─────────┐
+                   ┌─────────│  sent   │─────────┐
+                   │         └────┬────┘         │
+                   │              │              │
+          (error occurred)     (ready)   (signer refused)
+                   │              │              │
+                   ▼              ▼              ▼
+              ┌─────────┐    ┌─────────┐    ┌─────────┐
+              │ errored │    │ to_sign │    │ refused │
+              └─────────┘    └────┬────┘    └─────────┘
+                                  │
+                         (documents signed)
+                                  │
+                                  ├──────────────┐
+                                  │              │
+                  (sent back successfully)  (send back failed)
+                                  │              │
+                                  ▼              │
+                            ┌──────────┐         │
+                            │ returned │         │
+                            └─────┬────┘         │
+                                  │              │
+                       (documents received)      │
+                                  │              │
+                                  ▼              ▼
+                            ┌───────────┐   ┌─────────┐
+                            │ finalized │   │ signed  │
+                            └───────────┘   └─────────┘
     """
     return {
-        'draft': u'The session is getting ready to be sent to Paraphéo by a signing manager.',
-        'sent': u'The session has been sent to Paraphéo.',
-        'errored': u'The session encountered an error during its processing.',
-        'to_sign': u'The session is ready to be signed in Paraphéo.',
-        'signed': u'The session is finished but signed documents couldn\'t be sent back to the application.',
-        'refused': u'The session has been cancelled because a signer refused a document.',
-        'returned': u'The session is finished and signed documents are on the way back to the application.',
-        'finalized': u'The session is finished and signed documents have been sent back to the application.',
+        "draft": u"The session is getting ready to be sent to Paraphéo by a signing manager.",
+        "complete": u"The session is full (max size or max files reached) and will not accept any more batches; "
+        u"it is awaiting being sent to Paraphéo.",
+        "sent": u"The session has been sent to Paraphéo.",
+        "errored": u"The session encountered an error during its processing.",
+        "to_sign": u"The session is ready to be signed in Paraphéo.",
+        "signed": u"The session is finished but signed documents couldn't be sent back to the application.",
+        "refused": u"The session has been cancelled because a signer refused a document.",
+        "returned": u"The session is finished and signed documents are on the way back to the application.",
+        "finalized": u"The session is finished and signed documents have been sent back to the application.",
     }.get(state, "")
 
 

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -10,6 +10,7 @@ from imio.esign import logger
 from imio.esign.audit import audit
 from imio.esign.config import get_esign_registry_external_watchers
 from imio.esign.config import get_esign_registry_file_url
+from imio.esign.config import get_esign_registry_max_session_files
 from imio.esign.config import get_esign_registry_max_session_size
 from imio.esign.config import get_esign_registry_seal_code
 from imio.esign.config import get_esign_registry_seal_email
@@ -48,58 +49,67 @@ def get_filesize(uid):
     return getattr(annex.__parent__, "categorized_elements", {}).get(uid, {}).get("filesize", annex.file.size)
 
 
-def add_files_to_session(
+def add_files_to_session(  # noqa C901
     signers, files_uids, seal=None, acroform=True, session_id=None, title="", discriminators=(), watchers=(),
     create_session_custom_data=None
 ):
     """Add files to a session with the given signers.
 
+    Files are dispatched one by one. When the current target session would exceed
+    ``max_session_size`` or ``max_session_files`` by adding the next file, it is
+    marked as ``complete`` (so it will never be reused) and a new session is
+    discriminated or created for the remaining files.
+
     :param signers: a list of signers, each is a quartet with userid, email, fullname and position text
     :param files_uids: files uids list
     :param seal: seal or not
     :param acroform: boolean to indicate if signer tag is in files
-    :param session_id: session number
+    :param session_id: explicit session number. When given, no dispatching is performed: all files
+        go into this session even if it overflows the configured limits.
     :param title: optional string for session title. If it contains {sign_id} or {session_id} it will be replaced
     :param discriminators: optional list of string discriminators to use for session discrimination
     :param watchers: optional list of external esign session watchers emails (used only when creating a new session)
     :param create_session_custom_data: optional custom dict of custom session data
-    :return: session_id, session
+    :return: list of (session_id, session) tuples, one entry per distinct session used
     """
     annot = get_session_annotation()
-    size = sum(get_filesize(uid) for uid in files_uids)
+    session = None
     if session_id is not None:
         if session_id not in annot["sessions"]:
             logger.error("Session with id %s not found in esign annotations.", session_id)
-            session_id = session = None
+            session_id = None
         else:
             session = annot["sessions"][session_id]
-    else:
-        session_id, session = discriminate_sessions(signers, seal, acroform, discriminators=discriminators, size=size)
-    if not session:
-        session_id, session = create_session(
-            signers, seal, acroform=acroform, title=title, annot=annot, discriminators=discriminators,
-            watchers=watchers,
-            create_session_custom_data=create_session_custom_data,
-        )
-        audit(
-            "create_session",
-            "session={} signers={}".format(session_id, "|".join([sg[1] for sg in signers]))
-        )
-    session["size"] = session.get("size", 0) + size
-    existing_files = [path.splitext(f["filename"])[0] for f in session["files"]]
+    dispatch = session_id is None
+    sessions_used = []
+
     for uid in files_uids:
+        file_size = get_filesize(uid)
+
+        if dispatch:
+            session_id, session = discriminate_sessions(
+                signers, seal, acroform, discriminators=discriminators, size=file_size, files_count=1,
+            )
+            if not session:
+                session_id, session = create_session(
+                    signers, seal, acroform=acroform, title=title, annot=annot,
+                    discriminators=discriminators, watchers=watchers,
+                    create_session_custom_data=create_session_custom_data,
+                )
+                audit(
+                    "create_session",
+                    "session={} signers={}".format(session_id, "|".join([sg[1] for sg in signers]))
+                )
+
         annex = uuidToObject(uuid=uid, unrestricted=True)
         context_uid_provider = getAdapter(annex, IContextUidProvider)
         context_uid = context_uid_provider.get_context_uid()
         # update data if adding same file to same session
         if annot['uids'].get(uid, -1) == session_id:
             logger.info('File with UID %s is already in session_id %s and data were updated!', uid, session_id)
-            # remove old filename to avoid filename being renamed
-            old_filename = path.splitext([fn for fn in session["files"]
-                                          if fn['uid'] == uid][0]['filename'])[0]
-            existing_files.remove(old_filename)
             remove_files_from_session([uid], remove_empty_session=False)
 
+        existing_files = [path.splitext(f["filename"])[0] for f in session["files"]]
         filename, ext = path.splitext(annex.file.filename or "no_filename.pdf")
         new_filename = get_correct_id(existing_files, filename)
         file_dict = PersistentMapping({
@@ -134,23 +144,25 @@ def add_files_to_session(
             session["files"][context_start_idx:context_end_idx + 1] = sorted(
                 files, key=lambda f: uid_order.get(f["uid"], -1)
             )
-        existing_files.append(new_filename)
+        session["size"] = session.get("size", 0) + file_size
         annot["uids"][uid] = session_id
         annot["c_uids"].setdefault(context_uid, PersistentList()).append(uid)
         audit(
             "add_files_to_session",
             "session={} context={} file={}".format(session_id, context_uid, uid)
         )
-    if session["client_id"] is None:
-        # FIXME what if scan_id is None ?
-        session["client_id"] = session["files"][0]["scan_id"][0:7]
-        session["sign_id"] = "{}{:05d}".format(session["client_id"], session_id)
-        if u"{sign_id}" in session["title"]:
-            session["title"] = session["title"].replace(u"{sign_id}", session["sign_id"])
-        if u"{session_id}" in session["title"]:
-            session["title"] = session["title"].replace(u"{session_id}", str(session_id))
-    session["last_update"] = datetime.now()
-    return session_id, session
+        if session["client_id"] is None:
+            # FIXME what if scan_id is None ?
+            session["client_id"] = session["files"][0]["scan_id"][0:7]
+            session["sign_id"] = "{}{:05d}".format(session["client_id"], session_id)
+            if u"{sign_id}" in session["title"]:
+                session["title"] = session["title"].replace(u"{sign_id}", session["sign_id"])
+            if u"{session_id}" in session["title"]:
+                session["title"] = session["title"].replace(u"{session_id}", str(session_id))
+        session["last_update"] = datetime.now()
+        if not sessions_used or sessions_used[-1][0] != session_id:
+            sessions_used.append((session_id, session))
+    return sessions_used
 
 
 def create_external_session(session_id, esign_root_url=None):
@@ -289,7 +301,8 @@ def create_session(signers, seal=False, acroform=True, title=None, annot=None, d
         "sign_url": None,
         "signers": PersistentList(
             [
-                PersistentMapping({"userid": userid, "email": email, "fullname": fullname, "position": position, "status": ""})
+                PersistentMapping({"userid": userid, "email": email, "fullname": fullname, "position": position,
+                                   "status": ""})
                 for userid, email, fullname, position in signers
             ]
         ),
@@ -304,21 +317,23 @@ def create_session(signers, seal=False, acroform=True, title=None, annot=None, d
     return session_id, sessions[session_id]
 
 
-def discriminate_sessions(signers, seal, acroform, discriminators=(), annot=None, size=0):
+def discriminate_sessions(signers, seal, acroform, discriminators=(), annot=None, size=0, files_count=0):
     """Discriminate sessions based on seal value and signers in the same order.
 
     :param signers: a list of signers, each is a quartet with userid, email, fullname and position text
     :param seal: seal boolean
     :param acroform: boolean value indicating if acroform is used
     :param discriminators: optional list of string discriminators
-    :param size: size in bytes of the files to be added to the session
     :param annot: esign annotation, if not provided it will be fetched
+    :param size: size in bytes of the files to be added to the session
+    :param files_count: number of files to be added to the session
     :return: session id and session if found, or (None, None) if no session found
     """
     if not annot:
         annot = get_session_annotation()
     sessions = annot.get("sessions", {})
     max_session_size = get_esign_registry_max_session_size() * 1024**2
+    max_session_files = get_esign_registry_max_session_files()
 
     for session_id, session in sessions.items():
         if session["state"] != "draft":
@@ -330,17 +345,22 @@ def discriminate_sessions(signers, seal, acroform, discriminators=(), annot=None
         session_signers = session.get("signers", [])
         if len(signers) != len(session_signers):
             continue
-        if size + session.get("size", 0) > max_session_size:
-            continue
-
         if set(discriminators) != set(session.get("discriminators", ())):
             continue
-
         signers_match = all(
             (userid, email) == (s["userid"], s["email"]) for (userid, email, z, z), s in zip(signers, session_signers)
         )
-        if signers_match:
-            return session_id, session
+        if not signers_match:
+            continue
+        session_size = session.get("size", 0)
+        session_files_count = len(session.get("files", []))
+        if session_files_count + files_count > max_session_files or size + session_size > max_session_size:
+            # Session can't accept this batch. Mark it complete, so it will never be reconsidered for any future batch.
+            session["state"] = "complete"
+            session["last_update"] = datetime.now()
+            continue
+
+        return session_id, session
 
     return None, None
 
@@ -421,7 +441,8 @@ def remove_files_from_session(files_uids, remove_empty_session=True):
     """Remove files from their corresponding sessions.
 
     :param files_uids: list of file UIDs to remove
-    :param remove_empty_session: when the last file of a session is removed the session will be removed by default, except when False, the empty session is kept
+    :param remove_empty_session: when the last file of a session is removed the session will be removed by default,
+           except when False, the empty session is kept
     """
     annot = get_session_annotation()
     sessions = annot["sessions"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable max files per eSign session (default: 25).
  * Large uploads automatically split across multiple sessions; success messages show one or more session IDs.

* **Bug Fixes / Behavior**
  * Sessions can enter a new "draft_full" state to prevent reuse when limits are reached.
  * Re-adding a file replaces the existing entry in the same session.

* **Chores**
  * Install/profile configuration reorganized and metadata version bumped; upgrade steps added.

* **UX**
  * Minor table/tooltip formatting and expanded action availability.

* **Tests**
  * Updated tests to reflect multi-session returns and new registry setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IMIO/imio.esign/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->