### PR TITLE
In `@@session-annotation-info` display `UID` next to link to element.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Changelog
   [chris-adam]
 - Added parameter to define session files number limit
   [sgeulette]
+- In `@@session-annotation-info` display `UID` next to link to element.
+  [gbastien]
+- Fixed session size computation when an annex is deleted.
+  [gbastien]
 
 1.0b8 (2026-05-08)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,10 @@ Changelog
 1.0b10 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Fixed session size computation when an annex is deleted.
+  [gbastien]
+- In `@@session-annotation-info` display `UID` next to link to element.
+  [gbastien]
 
 1.0b9 (2026-06-02)
 ------------------
@@ -17,10 +19,6 @@ Changelog
   [chris-adam]
 - Added parameter to define session files number limit
   [sgeulette]
-- In `@@session-annotation-info` display `UID` next to link to element.
-  [gbastien]
-- Fixed session size computation when an annex is deleted.
-  [gbastien]
 
 1.0b8 (2026-05-08)
 ------------------

--- a/src/imio/esign/browser/actions.py
+++ b/src/imio/esign/browser/actions.py
@@ -167,7 +167,7 @@ class SessionAnnotationInfoView(BrowserView):
         url = escape(obj.absolute_url() + "/view", quote=True)
         path = escape(u"/".join(obj.getPhysicalPath()))
         title = escape(safe_unicode(getattr(obj, "title", "") or path))
-        return u"<a href='{}' title='{}'>{}</a>".format(url, path, title)
+        return u"<a href='{}' title='{}'>{}</a> ({})".format(url, path, title, uid)
 
     def _render_value(self, value, indent=u""):
         """Render a value, replacing UIDs with links where possible."""

--- a/src/imio/esign/configure.zcml
+++ b/src/imio/esign/configure.zcml
@@ -4,6 +4,7 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:plone="http://namespaces.plone.org/plone"
     xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="imio.esign">
 
   <i18n:registerTranslations directory="locales" />
@@ -26,5 +27,11 @@
     factory=".adapters.FilesBelongingToAGivenSession"
     provides="collective.compoundcriterion.interfaces.ICompoundCriterionFilter"
     name="files-belonging-to-a-given-session" />
+
+  <subscriber
+    zcml:condition="installed imio.annex"
+    for="imio.annex.content.annex.IAnnex
+         OFS.interfaces.IObjectWillBeRemovedEvent"
+    handler=".events.on_annex_will_be_removed" />
 
 </configure>

--- a/src/imio/esign/events.py
+++ b/src/imio/esign/events.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from imio.esign.utils import get_file_info
+from imio.esign.utils import get_session_annotation
 from imio.esign.utils import get_sessions_for
 from imio.esign.utils import remove_files_from_session
 from imio.helpers.transmogrifier import get_correct_id
@@ -67,5 +68,9 @@ def on_categorized_annex_updated(annex, event):
 
 def on_annex_will_be_removed(annex, event):
     '''Called when an annex will be removed, before the removed event.'''
-    # here annex is already unindexed
-    remove_files_from_session([annex.UID()])
+    annex_uid = annex.UID()
+    annot = get_session_annotation()
+    if annex_uid in annot['uids']:
+        # remove it from any esign session, need done before removed from categorized_elements
+        # nevertheless, here annex is already unindexed
+        remove_files_from_session([annex_uid])

--- a/src/imio/esign/events.py
+++ b/src/imio/esign/events.py
@@ -2,6 +2,7 @@
 
 from imio.esign.utils import get_file_info
 from imio.esign.utils import get_sessions_for
+from imio.esign.utils import remove_files_from_session
 from imio.helpers.transmogrifier import get_correct_id
 from os import path
 
@@ -62,3 +63,9 @@ def on_categorized_annex_updated(annex, event):
                         file_data['filename'] = new_filename + ext
                     # file_uid is only there one time per session
                     break
+
+
+def on_annex_will_be_removed(annex, event):
+    '''Called when an annex will be removed, before the removed event.'''
+    # here annex is already unindexed
+    remove_files_from_session([annex.UID()])

--- a/src/imio/esign/testing.py
+++ b/src/imio/esign/testing.py
@@ -45,7 +45,8 @@ class ImioEsignLayer(PloneSandboxLayer):
         import imio.annex
 
         self.loadZCML(package=imio.annex)
-        self.loadZCML(package=imio.esign)
+        self.loadZCML(package=imio.esign,
+                      name='testing.zcml')
 
     def setUpPloneSite(self, portal):
         setLocal("request", portal.REQUEST)

--- a/src/imio/esign/testing.zcml
+++ b/src/imio/esign/testing.zcml
@@ -7,8 +7,4 @@
 
   <include file="configure.zcml" />
 
-  <subscriber for="imio.annex.content.annex.IAnnex
-                   OFS.interfaces.IObjectWillBeRemovedEvent"
-              handler=".tests.events.on_annex_will_be_removed" />
-
 </configure>

--- a/src/imio/esign/testing.zcml
+++ b/src/imio/esign/testing.zcml
@@ -1,0 +1,14 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:five="http://namespaces.zope.org/five"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
+
+  <include file="configure.zcml" />
+
+  <subscriber for="imio.annex.content.annex.IAnnex
+                   OFS.interfaces.IObjectWillBeRemovedEvent"
+              handler=".tests.events.on_annex_will_be_removed" />
+
+</configure>

--- a/src/imio/esign/tests/events.py
+++ b/src/imio/esign/tests/events.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from imio.esign.utils import remove_files_from_session
+
+
+def on_annex_will_be_removed(annex, event):
+    '''Called when an annex will be removed, before the removed event.'''
+    # here annex is already unindexed
+    remove_files_from_session([annex.UID()])

--- a/src/imio/esign/tests/events.py
+++ b/src/imio/esign/tests/events.py
@@ -1,9 +1,0 @@
-# -*- coding: utf-8 -*-
-
-from imio.esign.utils import remove_files_from_session
-
-
-def on_annex_will_be_removed(annex, event):
-    '''Called when an annex will be removed, before the removed event.'''
-    # here annex is already unindexed
-    remove_files_from_session([annex.UID()])

--- a/src/imio/esign/tests/test_actions.py
+++ b/src/imio/esign/tests/test_actions.py
@@ -159,11 +159,11 @@ class TestSessionAnnotationInfoView(BaseEsignTest):
         uid = self.folder.UID()
         self.assertEqual(
             self.view._uid_to_link(uid),
-            u"<a href='http://nohost/plone/folder0/view' title='/plone/folder0'>Folder 0</a>",
+            u"<a href='http://nohost/plone/folder0/view' title='/plone/folder0'>Folder 0</a> ({0})".format(uid)
         )
         self.assertEqual(
             self.view._uid_to_link(u"a" * 32),
-            u"<span title='not found'>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</span>",
+            u"<span title='not found'>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</span>"
         )
 
     def test_esign_sessions(self):
@@ -210,6 +210,7 @@ class TestSessionAnnotationInfoView(BaseEsignTest):
         del self.portal.REQUEST.form["context_uid"]
 
         # Rendered HTML for first session
+        folder_uid = self.folder.UID()
         self.assertEqual(
             unescape(view.esign_session_html(esign_session[1])),
             u"""{{
@@ -218,23 +219,23 @@ class TestSessionAnnotationInfoView(BaseEsignTest):
   'discriminators': [],
   'files': [
     {{
-      'context_uid': <a href='http://nohost/plone/folder0/view' title='/plone/folder0'>Folder 0</a>,
+      'context_uid': <a href='http://nohost/plone/folder0/view' title='/plone/folder0'>Folder 0</a> ({0}),
       'filename': u'annex0.pdf',
       'scan_id': '012345600000000',
       'status': '',
       'title': u'Annex 0',
-      'uid': <a href='http://nohost/plone/folder0/annex0/view' title='/plone/folder0/annex0'>Annex 0</a>,
+      'uid': <a href='http://nohost/plone/folder0/annex0/view' title='/plone/folder0/annex0'>Annex 0</a> ({1}),
     }},
     {{
-      'context_uid': <a href='http://nohost/plone/folder0/view' title='/plone/folder0'>Folder 0</a>,
+      'context_uid': <a href='http://nohost/plone/folder0/view' title='/plone/folder0'>Folder 0</a> ({2}),
       'filename': u'annex2.pdf',
       'scan_id': '012345600000002',
       'status': '',
       'title': u'Annex 2',
-      'uid': <a href='http://nohost/plone/folder0/annex2/view' title='/plone/folder0/annex2'>Annex 2</a>,
+      'uid': <a href='http://nohost/plone/folder0/annex2/view' title='/plone/folder0/annex2'>Annex 2</a> ({3}),
     }},
   ],
-  'last_update': {},
+  'last_update': {4},
   'returns': [],
   'seal': None,
   'sign_id': '012345600000',
@@ -260,6 +261,10 @@ class TestSessionAnnotationInfoView(BaseEsignTest):
   'title': u'[ia.parapheo] Session 012345600000',
   'watchers': [],
 }}""".format(
-                repr(esign_session[1]["last_update"]),
+    folder_uid,
+    self.annexes[0].UID(),
+    folder_uid,
+    self.annexes[1].UID(),
+    repr(esign_session[1]["last_update"]),
             ),
         )

--- a/src/imio/esign/tests/test_utils.py
+++ b/src/imio/esign/tests/test_utils.py
@@ -246,7 +246,7 @@ class TestUtils(BaseEsignTest):
         sid, ses = add_files_to_session(signers, (last_annex_uid,))[-1]
         self.assertEqual(ses["size"], 13982)
         api.content.delete(last_annex)
-        self.failIf(api.portal.get_tool('portal_catalog')(UID=last_annex_uid))
+        self.assertFalse(api.portal.get_tool('portal_catalog')(UID=last_annex_uid))
         self.assertEqual(ses["size"], 6968)
 
         # --- size-based session splitting ---

--- a/src/imio/esign/tests/test_utils.py
+++ b/src/imio/esign/tests/test_utils.py
@@ -240,6 +240,14 @@ class TestUtils(BaseEsignTest):
         notify(ObjectModifiedEvent(annex2))
         remove_files_from_session((annex0_uid,))
         self.assertEqual(ses["size"], 6968)
+        # works also when annex deleted
+        last_annex_uid = self.uids[-1]
+        last_annex = api.content.get(UID=last_annex_uid)
+        sid, ses = add_files_to_session(signers, (last_annex_uid,))[-1]
+        self.assertEqual(ses["size"], 13982)
+        api.content.delete(last_annex)
+        self.failIf(api.portal.get_tool('portal_catalog')(UID=last_annex_uid))
+        self.assertEqual(ses["size"], 6968)
 
         # --- size-based session splitting ---
         del root_annot["imio.esign"]

--- a/src/imio/esign/utils.py
+++ b/src/imio/esign/utils.py
@@ -36,17 +36,27 @@ import requests
 SESSION_URL = "imio/esign/v1/luxtrust/sessions"
 
 
-def get_filesize(uid):
+def get_filesize(uid, session=None):
     """Get the file size of an annex.
 
     :param uid: The UID of the annex.
     :return: The file size in bytes, or 0 if not found.
     """
+    parent = None
     annex = uuidToObject(uuid=uid, unrestricted=True)
     if not annex:
-        logger.error("Annex with UID %s not found.", uid)
-        return 0
-    return getattr(annex.__parent__, "categorized_elements", {}).get(uid, {}).get("filesize", annex.file.size)
+        # try to get context from session in case annex was not found
+        # this can happen if we are in an event of a deleted annex
+        if session is not None:
+            for file_info in session['files']:
+                if file_info['uid'] == uid:
+                    parent = uuidToObject(uuid=file_info['context_uid'], unrestricted=True)
+                    break
+        if parent is None:
+            logger.error("Annex with UID %s not found.", uid)
+            return 0
+    parent = parent or annex.__parent__
+    return getattr(parent, "categorized_elements", {}).get(uid, {}).get("filesize", annex.file.size if annex else 0)
 
 
 def add_files_to_session(  # noqa C901
@@ -155,9 +165,9 @@ def add_files_to_session(  # noqa C901
                 uid_order = {a.UID(): idx for idx, a in enumerate(context.values())}
             else:
                 uid_order = {}
-            files = session["files"][context_start_idx : context_end_idx + 1]
+            files = session["files"][context_start_idx: context_end_idx + 1]
             files.append(file_dict)
-            session["files"][context_start_idx : context_end_idx + 1] = sorted(
+            session["files"][context_start_idx: context_end_idx + 1] = sorted(
                 files, key=lambda f: uid_order.get(f["uid"], -1)
             )
         session["size"] = session.get("size", 0) + file_size
@@ -472,8 +482,9 @@ def remove_files_from_session(files_uids, remove_empty_session=True):
     """Remove files from their corresponding sessions.
 
     :param files_uids: list of file UIDs to remove
-    :param remove_empty_session: when the last file of a session is removed the session will be removed by default,
-           except when False, the empty session is kept
+    :param remove_empty_session: when the last file of a session is removed
+           the session will be removed by default, except when False,
+           the empty session is kept
     """
     annot = get_session_annotation()
     sessions = annot["sessions"]
@@ -490,7 +501,7 @@ def remove_files_from_session(files_uids, remove_empty_session=True):
             logger.error("Session %s not found", session_id)
             continue
         session = sessions[session_id]
-        session["size"] = max(0, session.get("size", 0) - get_filesize(uid))
+        session["size"] = max(0, session.get("size", 0) - get_filesize(uid, session))
         i = 0
         context_uid = None
         for j, dic in enumerate(session["files"]):
@@ -635,7 +646,8 @@ def get_state_description(state):
     """
     return {
         "draft": u"The session is getting ready to be sent to Paraphéo by a signing manager.",
-        "draft_full": u"The session is full (max size or max files reached) and is ready to be sent to Paraphéo by a signing manager.",
+        "draft_full": u"The session is full (max size or max files reached) and is ready to be "
+        u"sent to Paraphéo by a signing manager.",
         "sent": u"The session has been sent to Paraphéo.",
         "errored": u"The session encountered an error during its processing.",
         "to_sign": u"The session is ready to be signed in Paraphéo.",


### PR DESCRIPTION
 + Fixed session size computation when an annex is deleted. See #PARAF-464
J'avais déjà des petits changements pour afficher l'uid dans la vue "annotations info", j'ai tout mis dans cette PR.
Tout çà pour dire qu'il faut appeler "remove_files_from_session" dans un WillBeRemovedEvent sinon la taille de la session n'est pas correcte...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UID identifiers now display next to element links in session annotation information.

* **Bug Fixes**
  * Fixed session size computation when annexes are deleted.
  * Sessions now remove file entries for deleted annexes so displayed session sizes remain accurate and up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->