### PR TITLE
Display annex description in `@@parapheo` quick look column.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ Changelog
   [gbastien]
 - In `@@session-annotation-info` display `UID` next to link to element.
   [gbastien]
+- Display annex description in `@@parapheo` quick look column.
+  Added parameter `session_id` to `SessionFilesView.__call__` to avoid having to
+  get it from the `request`, we receive it directly as integer.
+  [gbastien]
 
 1.0b9 (2026-06-02)
 ------------------

--- a/src/imio/esign/browser/table.py
+++ b/src/imio/esign/browser/table.py
@@ -175,7 +175,7 @@ class FilesColumn(Column):
             u'<div id="session-files" class="collapsible" '
             u"onclick=\"toggleDetails('collapsible-session-files_{0}', "
             u"toggle_parent_active=true, parent_tag=null, "
-            u"load_view='@@esign-session-files?session_id={0}', "
+            u"load_view='@@esign-session-files?session_id:int={0}', "
             u"base_url='{1}');\"> {2}</div>"
             u'<div id="collapsible-session-files_{0}" class="collapsible-content" style="display: none;">'
             u'<div class="collapsible-inner-content">'

--- a/src/imio/esign/browser/views.py
+++ b/src/imio/esign/browser/views.py
@@ -41,6 +41,7 @@ from zope.pagetemplate.pagetemplate import PageTemplate
 from zope.publisher.interfaces import IPublishTraverse
 
 import csv
+import html
 import json
 import os
 
@@ -117,6 +118,7 @@ class SessionFilesView(BrowserView):
         descr = obj.Description().strip()
         if descr:
             # description is plain text
+            descr = html.escape(descr)
             descr = descr.replace("\n", "<br>")
             descr = u"<div class='discreet'>{0}</div>".format(safe_unicode(descr))
         return descr

--- a/src/imio/esign/browser/views.py
+++ b/src/imio/esign/browser/views.py
@@ -29,6 +29,7 @@ from plone import api
 from plone.app.layout.viewlets import ViewletBase
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import base_hasattr
+from Products.CMFPlone.utils import safe_unicode
 from Products.Five import BrowserView
 from Products.PageTemplates.Expressions import SecureModuleImporter
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
@@ -97,8 +98,7 @@ class SessionFilesView(BrowserView):
         super(SessionFilesView, self).__init__(context, request)
         self.files = []
 
-    def __call__(self):
-        session_id = int(self.request.get("session_id"))
+    def __call__(self, session_id):
         session = self.get_session(session_id)
         files = []
         for f in session["files"]:
@@ -113,8 +113,17 @@ class SessionFilesView(BrowserView):
         """Get the session object."""
         return get_session_annotation()["sessions"][session_id]
 
+    def _get_file_link_descr(self, ctx, obj):
+        descr = obj.Description().strip()
+        if descr:
+            # description is plain text
+            descr = descr.replace("\n", "<br>")
+            descr = u"<div class='discreet'>{0}</div>".format(safe_unicode(descr))
+        return descr
+
     def get_file_link(self, ctx, obj):
-        return IPrettyLink(ctx).getLink() + " / " + IPrettyLink(obj).getLink()
+        descr = self._get_file_link_descr(ctx, obj)
+        return IPrettyLink(ctx).getLink() + " / " + IPrettyLink(obj).getLink() + descr
 
 
 class SessionDeleteView(BrowserView):

--- a/src/imio/esign/tests/test_browser_views.py
+++ b/src/imio/esign/tests/test_browser_views.py
@@ -646,3 +646,12 @@ class TestSessionsListingView(BaseEsignTest):
         # get_dashboard_link will raise NotImplementedError
         with self.assertRaises(NotImplementedError):
             view()
+
+    def test_session_files(self):
+        """Test the quick look column that will call the @@esign-session-files view."""
+        annex = self.portal["folder0"]["annex0"]
+        annex.setDescription("Descr line 1\nDescr line 2 héhé")
+        view = self.portal.restrictedTraverse("@@esign-session-files")
+        result = view(0)
+        self.assertTrue(u"http://nohost/plone/folder0/annex0/@@download" in result)
+        self.assertTrue(u"<div class=\'discreet\'>Descr line 1<br>Descr line 2 h\xe9h\xe9</div>" in result)

--- a/src/imio/esign/tests/test_browser_views.py
+++ b/src/imio/esign/tests/test_browser_views.py
@@ -653,5 +653,9 @@ class TestSessionsListingView(BaseEsignTest):
         annex.setDescription("Descr line 1\nDescr line 2 héhé")
         view = self.portal.restrictedTraverse("@@esign-session-files")
         result = view(0)
-        self.assertTrue(u"http://nohost/plone/folder0/annex0/@@download" in result)
-        self.assertTrue(u"<div class=\'discreet\'>Descr line 1<br>Descr line 2 h\xe9h\xe9</div>" in result)
+        self.assertIn(u"http://nohost/plone/folder0/annex0/@@download", result)
+        self.assertIn(u"<div class=\'discreet\'>Descr line 1<br>Descr line 2 h\xe9h\xe9</div>", result)
+        # description is escaped
+        annex.setDescription("ok\n<script>alert(1)</script>")
+        result = view(0)
+        self.assertIn(u"<div class=\'discreet\'>ok<br>&lt;script&gt;alert(1)&lt;/script&gt;</div>", result)

--- a/src/imio/esign/tests/test_browser_views.py
+++ b/src/imio/esign/tests/test_browser_views.py
@@ -659,3 +659,7 @@ class TestSessionsListingView(BaseEsignTest):
         annex.setDescription("ok\n<script>alert(1)</script>")
         result = view(0)
         self.assertIn(u"<div class=\'discreet\'>ok<br>&lt;script&gt;alert(1)&lt;/script&gt;</div>", result)
+        # without description
+        annex.setDescription("")
+        result = view(0)
+        self.assertNotIn(u"discreet", result)


### PR DESCRIPTION
Added parameter `session_id` to `SessionFilesView.__call__` to avoid having to get it from the `request`, we receive it directly as integer. See #PARAF-470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session files view now shows annex descriptions inline, preserving line breaks and non‑ASCII characters.
  * Descriptions are rendered safely (HTML‑escaped) to prevent script injection and are omitted when empty.
* **Tests**
  * Added tests verifying description formatting, escaping, and presence/absence of the discreet description markup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->