### PR TITLE
Added red/green icon next to signers to show if not signed or signed.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Changelog
   Added parameter `session_id` to `SessionFilesView.__call__` to avoid having to
   get it from the `request`, we receive it directly as integer.
   [gbastien]
+- Added red/green icon next to signers to show if not signed or signed.
+  In info viewlet, display `signed` in green.
+  [gbastien]
 
 1.0b9 (2026-06-02)
 ------------------

--- a/src/imio/esign/browser/table.py
+++ b/src/imio/esign/browser/table.py
@@ -17,6 +17,8 @@ from z3c.table.table import Table
 from zope.component import getMultiAdapter
 from zope.i18n import translate
 
+import html
+
 
 class IdColumn(Column):
     # not translated so it stays short
@@ -105,12 +107,19 @@ class SignersColumn(Column):
     def renderCell(self, item):
         signers = item.get("signers") or []
         parts = [
-            "<li>%s, %s%s (%s)</li>" % (
+            "<li>%s, %s (%s) %s</li>" % (
                 safe_encode(s.get("fullname", "")),
                 safe_encode(s.get("position")),
-                " (%s)" % safe_encode(translate(s.get("status"), domain="imio.esign",
-                                                context=self.request)) if s.get("status") else "",
-                s.get("email"), )
+                s.get("email"),
+                "<span class='fa fa-edit help %s' title='%s'></span>" %
+                    ("signer-signed" if s.get("status") else "signer-not-signed",
+                     safe_encode(
+                        html.escape(
+                            translate(
+                                'status_title_signed' if s.get("status") else 'status_title_not_signed',
+                                domain="imio.esign",
+                                context=self.request)))),
+                )
             for s in signers
         ]
         return safe_unicode("<ol>%s</ol>" % "".join(parts))

--- a/src/imio/esign/browser/table.py
+++ b/src/imio/esign/browser/table.py
@@ -106,22 +106,33 @@ class SignersColumn(Column):
 
     def renderCell(self, item):
         signers = item.get("signers") or []
-        parts = [
-            "<li>%s, %s (%s) %s</li>" % (
-                safe_encode(s.get("fullname", "")),
-                safe_encode(s.get("position")),
-                s.get("email"),
-                "<span class='fa fa-edit help %s' title='%s'></span>" %
-                    ("signer-signed" if s.get("status") else "signer-not-signed",
-                     safe_encode(
-                        html.escape(
-                            translate(
-                                'status_title_signed' if s.get("status") else 'status_title_not_signed',
-                                domain="imio.esign",
-                                context=self.request)))),
-                )
-            for s in signers
-        ]
+        parts = []
+        for s in signers:
+            icon_name = 'edit'
+            css_class = "signer-not-signed"
+            msgid = "status_title_not_signed"
+            if s.get("status") == "signed":
+                css_class = "signer-signed"
+                msgid = "status_title_signed"
+            elif s.get("status") == "refused":
+                icon_name = 'ban'
+                css_class = "signer-refused"
+                msgid = "status_title_refused"
+            parts.append(
+                "<li>%s, %s (%s) %s</li>" % (
+                    safe_encode(s.get("fullname", "")),
+                    safe_encode(s.get("position")),
+                    s.get("email"),
+                    "<span class='fa fa-%s help %s' title='%s'></span>" %
+                        (icon_name,
+                         css_class,
+                         safe_encode(
+                            html.escape(
+                                translate(
+                                    msgid,
+                                    domain="imio.esign",
+                                    context=self.request)))),
+                    ))
         return safe_unicode("<ol>%s</ol>" % "".join(parts))
 
 

--- a/src/imio/esign/browser/templates/macros.pt
+++ b/src/imio/esign/browser/templates/macros.pt
@@ -56,7 +56,11 @@
                 <td tal:content="python:s['fullname']">Jean Dupont</td>
                 <td tal:content="python:s['position']">Directeur Général</td>
                 <td tal:content="python:s['email']">user1@sign.com</td>
-                <td tal:content="python:s['status'] or '-'" i18n:translate="" >pending</td>
+                <td>
+                  <span tal:attributes="class python: 'signer-signed' if s['status'] else ''"
+                        tal:content="python:s['status'] or '-'"
+                        i18n:translate="">pending</span>
+                </td>
             </tr>
             </tbody>
         </table>

--- a/src/imio/esign/browser/templates/macros.pt
+++ b/src/imio/esign/browser/templates/macros.pt
@@ -57,7 +57,7 @@
                 <td tal:content="python:s['position']">Directeur Général</td>
                 <td tal:content="python:s['email']">user1@sign.com</td>
                 <td>
-                  <span tal:attributes="class python: 'signer-signed' if s['status'] else ''"
+                  <span tal:attributes="class python: 'signer-%s' % s['status'] if s['status'] else ''"
                         tal:content="python:s['status'] or '-'"
                         i18n:translate="">pending</span>
                 </td>

--- a/src/imio/esign/locales/en/LC_MESSAGES/imio.esign.po
+++ b/src/imio/esign/locales/en/LC_MESSAGES/imio.esign.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-28 09:56+0000\n"
+"POT-Creation-Date: 2026-06-12 09:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 msgid "A file identifier must be passed in the url !"
 msgstr ""
 
-#: ../browser/table.py:206
+#: ../browser/table.py:212
 msgid "Actions"
 msgstr ""
 
@@ -39,11 +39,11 @@ msgstr ""
 msgid "Confirm Email Sending"
 msgstr ""
 
-#: ../browser/table.py:239
+#: ../browser/table.py:245
 msgid "Create external session"
 msgstr ""
 
-#: ../browser/table.py:225
+#: ../browser/table.py:231
 msgid "Delete session"
 msgstr ""
 
@@ -112,7 +112,7 @@ msgstr ""
 msgid "File URL download domain"
 msgstr ""
 
-#: ../browser/table.py:121
+#: ../browser/table.py:127
 msgid "Files"
 msgstr ""
 
@@ -153,7 +153,7 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: ../browser/table.py:190
+#: ../browser/table.py:196
 #: ../browser/templates/macros.pt:21
 msgid "Last update"
 msgstr ""
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Problem getting signers: \"${error}\")!"
 msgstr ""
 
-#: ../browser/table.py:150
+#: ../browser/table.py:156
 msgid "Quick look (${count} element(s), total size: ${size}) <span title='${help_title}' class='far fa-question-circle' />"
 msgstr ""
 
@@ -279,7 +279,7 @@ msgstr ""
 msgid "Send Emails"
 msgstr ""
 
-#: ../utils.py:207
+#: ../utils.py:217
 msgid "Session ${id}"
 msgstr ""
 
@@ -287,7 +287,7 @@ msgstr ""
 msgid "Session ID"
 msgstr ""
 
-#: ../browser/table.py:139
+#: ../browser/table.py:145
 msgid "Session can contain max ${max_session_files} elements and have a max size of ${max_session_size} MB."
 msgstr ""
 
@@ -458,7 +458,7 @@ msgstr ""
 msgid "VAT number used for esign billing (BE0123456789)."
 msgstr ""
 
-#: ../browser/table.py:256
+#: ../browser/table.py:262
 msgid "View session in dashboard"
 msgstr ""
 
@@ -517,6 +517,14 @@ msgstr "Sent"
 #: ../browser/table.py
 msgid "signed"
 msgstr "Signed"
+
+#: ../browser/table.py
+msgid "status_title_not_signed"
+msgstr ""
+
+#: ../browser/table.py
+msgid "status_title_signed"
+msgstr ""
 
 #: ../browser/table.py
 msgid "to_sign"

--- a/src/imio/esign/locales/en/LC_MESSAGES/imio.esign.po
+++ b/src/imio/esign/locales/en/LC_MESSAGES/imio.esign.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-12 09:13+0000\n"
+"POT-Creation-Date: 2026-06-16 08:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,11 +15,11 @@ msgstr ""
 "Domain: imio.dashboard\n"
 "X-is-fallback-for: en-au en-ca en-gb en-us\n"
 
-#: ../browser/views.py:317
+#: ../browser/views.py:328
 msgid "A file identifier must be passed in the url !"
 msgstr ""
 
-#: ../browser/table.py:212
+#: ../browser/table.py:226
 msgid "Actions"
 msgstr ""
 
@@ -39,11 +39,11 @@ msgstr ""
 msgid "Confirm Email Sending"
 msgstr ""
 
-#: ../browser/table.py:245
+#: ../browser/table.py:259
 msgid "Create external session"
 msgstr ""
 
-#: ../browser/table.py:231
+#: ../browser/table.py:245
 msgid "Delete session"
 msgstr ""
 
@@ -60,7 +60,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: ../browser/views.py:586
+#: ../browser/views.py:597
 msgid "Email content is not configured in the settings."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "Email:"
 msgstr ""
 
-#: ../browser/views.py:646
+#: ../browser/views.py:657
 msgid "Emails sent successfully to ${count} users."
 msgstr ""
 
@@ -88,11 +88,11 @@ msgstr ""
 msgid "Enabled?"
 msgstr ""
 
-#: ../browser/views.py:194
+#: ../browser/views.py:205
 msgid "Error while sending session: ${error}"
 msgstr ""
 
-#: ../browser/views.py:189
+#: ../browser/views.py:200
 msgid "External session sent successfully!"
 msgstr ""
 
@@ -100,11 +100,11 @@ msgstr ""
 msgid "External watchers emails"
 msgstr ""
 
-#: ../browser/views.py:633
+#: ../browser/views.py:644
 msgid "Failed to send email to ${userid}."
 msgstr ""
 
-#: ../browser/views.py:653
+#: ../browser/views.py:664
 msgid "Failed to send emails to ${count} users."
 msgstr ""
 
@@ -112,7 +112,7 @@ msgstr ""
 msgid "File URL download domain"
 msgstr ""
 
-#: ../browser/table.py:127
+#: ../browser/table.py:141
 msgid "Files"
 msgstr ""
 
@@ -153,7 +153,7 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: ../browser/table.py:196
+#: ../browser/table.py:210
 #: ../browser/templates/macros.pt:21
 msgid "Last update"
 msgstr ""
@@ -190,27 +190,27 @@ msgstr ""
 msgid "No files"
 msgstr ""
 
-#: ../browser/views.py:183
+#: ../browser/views.py:194
 msgid "No files found to be sent ! Session ${id} not sent."
 msgstr ""
 
-#: ../browser/views.py:169
+#: ../browser/views.py:180
 msgid "No seal code defined in configuration ! Session ${id} not sent."
 msgstr ""
 
-#: ../browser/views.py:176
+#: ../browser/views.py:187
 msgid "No seal email defined in configuration ! Session ${id} not sent."
 msgstr ""
 
-#: ../browser/views.py:128
+#: ../browser/views.py:139
 msgid "No session ID provided!"
 msgstr ""
 
-#: ../browser/views.py:541
+#: ../browser/views.py:552
 msgid "No users selected for CSV download."
 msgstr ""
 
-#: ../browser/views.py:580
+#: ../browser/views.py:591
 msgid "No users selected for email sending."
 msgstr ""
 
@@ -222,7 +222,7 @@ msgstr ""
 msgid "Parapheo url"
 msgstr ""
 
-#: ../browser/views.py:595
+#: ../browser/views.py:606
 msgid "Portal from email is not configured."
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Problem getting signers: \"${error}\")!"
 msgstr ""
 
-#: ../browser/table.py:156
+#: ../browser/table.py:170
 msgid "Quick look (${count} element(s), total size: ${size}) <span title='${help_title}' class='far fa-question-circle' />"
 msgstr ""
 
@@ -258,7 +258,7 @@ msgstr ""
 msgid "Seal email"
 msgstr ""
 
-#: ../browser/table.py:85
+#: ../browser/table.py:87
 #: ../browser/templates/macros.pt:28
 msgid "Sealed"
 msgstr ""
@@ -287,11 +287,11 @@ msgstr ""
 msgid "Session ID"
 msgstr ""
 
-#: ../browser/table.py:145
+#: ../browser/table.py:159
 msgid "Session can contain max ${max_session_files} elements and have a max size of ${max_session_size} MB."
 msgstr ""
 
-#: ../browser/views.py:136
+#: ../browser/views.py:147
 msgid "Session deleted successfully!"
 msgstr ""
 
@@ -299,7 +299,7 @@ msgstr ""
 msgid "Session information (${icon_url} Parapheo)"
 msgstr ""
 
-#: ../browser/views.py:138
+#: ../browser/views.py:149
 msgid "Session not found!"
 msgstr ""
 
@@ -307,7 +307,7 @@ msgstr ""
 msgid "Session not yet sent."
 msgstr ""
 
-#: ../browser/views.py:162
+#: ../browser/views.py:173
 msgid "Session with ID ${id} doesn't exist anymore !"
 msgstr ""
 
@@ -323,11 +323,11 @@ msgstr ""
 msgid "Sign url not yet received."
 msgstr ""
 
-#: ../browser/views.py:369
+#: ../browser/views.py:380
 msgid "Signed file download"
 msgstr ""
 
-#: ../browser/table.py:100
+#: ../browser/table.py:102
 #: ../browser/templates/macros.pt:42
 msgid "Signers"
 msgstr ""
@@ -336,7 +336,7 @@ msgstr ""
 msgid "Signing Users: Export CSV"
 msgstr ""
 
-#: ../browser/table.py:54
+#: ../browser/table.py:56
 #: ../browser/templates/macros.pt:11
 msgid "State"
 msgstr ""
@@ -345,15 +345,15 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: ../browser/views.py:345
+#: ../browser/views.py:356
 msgid "The corresponding file content cannot be retrieved (${uid}) !"
 msgstr ""
 
-#: ../browser/views.py:325
+#: ../browser/views.py:336
 msgid "The corresponding file identifier cannot be retrieved (${uid}) !"
 msgstr ""
 
-#: ../browser/views.py:337
+#: ../browser/views.py:348
 msgid "The download period for this file has expired (was ${valid_date}) !"
 msgstr ""
 
@@ -393,7 +393,7 @@ msgstr ""
 msgid "The session is ready to be signed in Paraphéo."
 msgstr ""
 
-#: ../browser/views.py:321
+#: ../browser/views.py:332
 msgid "This file identifier is not correct !"
 msgstr ""
 
@@ -409,7 +409,7 @@ msgstr ""
 msgid "This will remove this element or configured sub elements from the relevant esign session"
 msgstr ""
 
-#: ../browser/table.py:71
+#: ../browser/table.py:73
 #: ../browser/templates/macros.pt:35
 msgid "Title"
 msgstr ""
@@ -426,7 +426,7 @@ msgstr ""
 msgid "Used in signers email template."
 msgstr ""
 
-#: ../browser/views.py:604
+#: ../browser/views.py:615
 msgid "User ${userid} has no email address configured. Skipping."
 msgstr ""
 
@@ -458,7 +458,7 @@ msgstr ""
 msgid "VAT number used for esign billing (BE0123456789)."
 msgstr ""
 
-#: ../browser/table.py:262
+#: ../browser/table.py:276
 msgid "View session in dashboard"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "You are about to send emails to"
 msgstr ""
 
-#: ../browser/views.py:619
+#: ../browser/views.py:630
 msgid "You have been invited to Paraphéo"
 msgstr ""
 
@@ -520,6 +520,10 @@ msgstr "Signed"
 
 #: ../browser/table.py
 msgid "status_title_not_signed"
+msgstr ""
+
+#: ../browser/table.py
+msgid "status_title_refused"
 msgstr ""
 
 #: ../browser/table.py

--- a/src/imio/esign/locales/fr/LC_MESSAGES/imio.esign.po
+++ b/src/imio/esign/locales/fr/LC_MESSAGES/imio.esign.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-05-28 09:56+0000\n"
+"POT-Creation-Date: 2026-06-12 09:13+0000\n"
 "PO-Revision-Date: 2016-02-22 15:20+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -20,7 +20,7 @@ msgstr ""
 msgid "A file identifier must be passed in the url !"
 msgstr "Un identifiant de fichier doit être inclus dans l'URL !"
 
-#: ../browser/table.py:206
+#: ../browser/table.py:212
 msgid "Actions"
 msgstr "Actions"
 
@@ -40,11 +40,11 @@ msgstr "Annuler"
 msgid "Confirm Email Sending"
 msgstr "Confirmer l'envoi des emails"
 
-#: ../browser/table.py:239
+#: ../browser/table.py:245
 msgid "Create external session"
 msgstr "Envoyer dans Paraphéo"
 
-#: ../browser/table.py:225
+#: ../browser/table.py:231
 msgid "Delete session"
 msgstr "Effacer la session"
 
@@ -113,7 +113,7 @@ msgstr "Échec de l'envoi des emails pour ${count} utilisateurs."
 msgid "File URL download domain"
 msgstr "Nom de domaine de téléchargement"
 
-#: ../browser/table.py:121
+#: ../browser/table.py:127
 msgid "Files"
 msgstr "Fichiers"
 
@@ -154,7 +154,7 @@ msgstr "Active/désactive la fonctionnalité globalement sur le site."
 msgid "Last Name"
 msgstr "Nom"
 
-#: ../browser/table.py:190
+#: ../browser/table.py:196
 #: ../browser/templates/macros.pt:21
 msgid "Last update"
 msgstr "Dernière mise à jour"
@@ -235,7 +235,7 @@ msgstr "Fonction"
 msgid "Problem getting signers: \"${error}\")!"
 msgstr "Problème pour obtenir les signataires : \"${error}\" !"
 
-#: ../browser/table.py:150
+#: ../browser/table.py:156
 msgid "Quick look (${count} element(s), total size: ${size}) <span title='${help_title}' class='far fa-question-circle' />"
 msgstr "${count} élément(s), taille: ${size} <span title='${help_title}' class='far fa-question-circle' />"
 
@@ -280,7 +280,7 @@ msgstr "Sélectionnés:"
 msgid "Send Emails"
 msgstr "Envoyer des emails"
 
-#: ../utils.py:207
+#: ../utils.py:217
 msgid "Session ${id}"
 msgstr "Session ${id}"
 
@@ -288,7 +288,7 @@ msgstr "Session ${id}"
 msgid "Session ID"
 msgstr "Identifiant"
 
-#: ../browser/table.py:139
+#: ../browser/table.py:145
 msgid "Session can contain max ${max_session_files} elements and have a max size of ${max_session_size} MB."
 msgstr "Une session peut contenir maximum ${max_session_files} éléments pour une taille totale maximum de ${max_session_size} MB."
 
@@ -459,7 +459,7 @@ msgstr "Le numéro de TVA doit commencer par 'BE'"
 msgid "VAT number used for esign billing (BE0123456789)."
 msgstr "Numéro de TVA utilisé pour la facturation esign (BE0123456789)."
 
-#: ../browser/table.py:256
+#: ../browser/table.py:262
 msgid "View session in dashboard"
 msgstr "Voir la session dans un tableau de bord"
 
@@ -518,6 +518,14 @@ msgstr "Envoyée"
 #: ../browser/table.py
 msgid "signed"
 msgstr "Signée"
+
+#: ../browser/table.py
+msgid "status_title_not_signed"
+msgstr "Ce signataire n'a pas encore signé la session"
+
+#: ../browser/table.py
+msgid "status_title_signed"
+msgstr "Ce signataire a signé la session"
 
 #: ../browser/table.py
 msgid "to_sign"

--- a/src/imio/esign/locales/fr/LC_MESSAGES/imio.esign.po
+++ b/src/imio/esign/locales/fr/LC_MESSAGES/imio.esign.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-06-12 09:13+0000\n"
+"POT-Creation-Date: 2026-06-16 08:12+0000\n"
 "PO-Revision-Date: 2016-02-22 15:20+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -16,11 +16,11 @@ msgstr ""
 "Language: fr\n"
 "X-Generator: Poedit 1.8.4\n"
 
-#: ../browser/views.py:317
+#: ../browser/views.py:328
 msgid "A file identifier must be passed in the url !"
 msgstr "Un identifiant de fichier doit être inclus dans l'URL !"
 
-#: ../browser/table.py:212
+#: ../browser/table.py:226
 msgid "Actions"
 msgstr "Actions"
 
@@ -40,11 +40,11 @@ msgstr "Annuler"
 msgid "Confirm Email Sending"
 msgstr "Confirmer l'envoi des emails"
 
-#: ../browser/table.py:245
+#: ../browser/table.py:259
 msgid "Create external session"
 msgstr "Envoyer dans Paraphéo"
 
-#: ../browser/table.py:231
+#: ../browser/table.py:245
 msgid "Delete session"
 msgstr "Effacer la session"
 
@@ -61,7 +61,7 @@ msgstr "Élément retiré de la session !"
 msgid "Email"
 msgstr "E-mail"
 
-#: ../browser/views.py:586
+#: ../browser/views.py:597
 msgid "Email content is not configured in the settings."
 msgstr "Le modèle d'email n'est pas configuré dans les paramètres."
 
@@ -81,7 +81,7 @@ msgstr "Email du compte du fournisseur eidas contenant l'image du sceau."
 msgid "Email:"
 msgstr "Email:"
 
-#: ../browser/views.py:646
+#: ../browser/views.py:657
 msgid "Emails sent successfully to ${count} users."
 msgstr "Emails envoyés avec succès à ${count} utilisateurs."
 
@@ -89,11 +89,11 @@ msgstr "Emails envoyés avec succès à ${count} utilisateurs."
 msgid "Enabled?"
 msgstr "Activé?"
 
-#: ../browser/views.py:194
+#: ../browser/views.py:205
 msgid "Error while sending session: ${error}"
 msgstr "Erreur lors de l'envoi de la session : ${error}"
 
-#: ../browser/views.py:189
+#: ../browser/views.py:200
 msgid "External session sent successfully!"
 msgstr "Session externe envoyée avec succès !"
 
@@ -101,11 +101,11 @@ msgstr "Session externe envoyée avec succès !"
 msgid "External watchers emails"
 msgstr "Liste d'emails d'observateurs externes"
 
-#: ../browser/views.py:633
+#: ../browser/views.py:644
 msgid "Failed to send email to ${userid}."
 msgstr "Échec de l'envoi de l'email pour ${userid}."
 
-#: ../browser/views.py:653
+#: ../browser/views.py:664
 msgid "Failed to send emails to ${count} users."
 msgstr "Échec de l'envoi des emails pour ${count} utilisateurs."
 
@@ -113,7 +113,7 @@ msgstr "Échec de l'envoi des emails pour ${count} utilisateurs."
 msgid "File URL download domain"
 msgstr "Nom de domaine de téléchargement"
 
-#: ../browser/table.py:127
+#: ../browser/table.py:141
 msgid "Files"
 msgstr "Fichiers"
 
@@ -154,7 +154,7 @@ msgstr "Active/désactive la fonctionnalité globalement sur le site."
 msgid "Last Name"
 msgstr "Nom"
 
-#: ../browser/table.py:196
+#: ../browser/table.py:210
 #: ../browser/templates/macros.pt:21
 msgid "Last update"
 msgstr "Dernière mise à jour"
@@ -191,27 +191,27 @@ msgstr "Non"
 msgid "No files"
 msgstr "Aucun fichier"
 
-#: ../browser/views.py:183
+#: ../browser/views.py:194
 msgid "No files found to be sent ! Session ${id} not sent."
 msgstr "Aucun fichier référencé n'a été trouvé ! La session ${id} n'a pas été envoyée."
 
-#: ../browser/views.py:169
+#: ../browser/views.py:180
 msgid "No seal code defined in configuration ! Session ${id} not sent."
 msgstr "Aucun code de sceau défini dans la configuration ! La session ${id} n'a pas été envoyée."
 
-#: ../browser/views.py:176
+#: ../browser/views.py:187
 msgid "No seal email defined in configuration ! Session ${id} not sent."
 msgstr "Aucun email de sceau défini dans la configuration ! La session ${id} n'a pas été envoyée."
 
-#: ../browser/views.py:128
+#: ../browser/views.py:139
 msgid "No session ID provided!"
 msgstr "Aucun identifiant de session fourni !"
 
-#: ../browser/views.py:541
+#: ../browser/views.py:552
 msgid "No users selected for CSV download."
 msgstr "Aucun utilisateur sélectionné pour le téléchargement du CSV."
 
-#: ../browser/views.py:580
+#: ../browser/views.py:591
 msgid "No users selected for email sending."
 msgstr "Aucun utilisateur sélectionné pour l'envoi d'emails."
 
@@ -223,7 +223,7 @@ msgstr "Ouvrir la plateforme de signature électronique"
 msgid "Parapheo url"
 msgstr "Url de Paraphéo"
 
-#: ../browser/views.py:595
+#: ../browser/views.py:606
 msgid "Portal from email is not configured."
 msgstr "L'adresse d'expéditeur du site n'est pas configurée"
 
@@ -235,7 +235,7 @@ msgstr "Fonction"
 msgid "Problem getting signers: \"${error}\")!"
 msgstr "Problème pour obtenir les signataires : \"${error}\" !"
 
-#: ../browser/table.py:156
+#: ../browser/table.py:170
 msgid "Quick look (${count} element(s), total size: ${size}) <span title='${help_title}' class='far fa-question-circle' />"
 msgstr "${count} élément(s), taille: ${size} <span title='${help_title}' class='far fa-question-circle' />"
 
@@ -259,7 +259,7 @@ msgstr "Code fourni par le fournisseur eidas."
 msgid "Seal email"
 msgstr "Email du compte avec l'image du sceau"
 
-#: ../browser/table.py:85
+#: ../browser/table.py:87
 #: ../browser/templates/macros.pt:28
 msgid "Sealed"
 msgstr "Sceau"
@@ -288,11 +288,11 @@ msgstr "Session ${id}"
 msgid "Session ID"
 msgstr "Identifiant"
 
-#: ../browser/table.py:145
+#: ../browser/table.py:159
 msgid "Session can contain max ${max_session_files} elements and have a max size of ${max_session_size} MB."
 msgstr "Une session peut contenir maximum ${max_session_files} éléments pour une taille totale maximum de ${max_session_size} MB."
 
-#: ../browser/views.py:136
+#: ../browser/views.py:147
 msgid "Session deleted successfully!"
 msgstr "Session effacée avec succès !"
 
@@ -300,7 +300,7 @@ msgstr "Session effacée avec succès !"
 msgid "Session information (${icon_url} Parapheo)"
 msgstr "Session de signature électronique (${icon_url} Paraphéo)"
 
-#: ../browser/views.py:138
+#: ../browser/views.py:149
 msgid "Session not found!"
 msgstr "Session non trouvée !"
 
@@ -308,7 +308,7 @@ msgstr "Session non trouvée !"
 msgid "Session not yet sent."
 msgstr "La session n'a pas encore été envoyée."
 
-#: ../browser/views.py:162
+#: ../browser/views.py:173
 msgid "Session with ID ${id} doesn't exist anymore !"
 msgstr "La session avec l'ID ${id} n'existe plus !"
 
@@ -324,11 +324,11 @@ msgstr "Méthode de signature utilisée pour spécifier la méthode de signature
 msgid "Sign url not yet received."
 msgstr "Le lien de la session de signature n'a pas encore été reçu."
 
-#: ../browser/views.py:369
+#: ../browser/views.py:380
 msgid "Signed file download"
 msgstr "Téléchargement du fichier signé"
 
-#: ../browser/table.py:100
+#: ../browser/table.py:102
 #: ../browser/templates/macros.pt:42
 msgid "Signers"
 msgstr "Signataires"
@@ -337,7 +337,7 @@ msgstr "Signataires"
 msgid "Signing Users: Export CSV"
 msgstr "Signataires: csv pour WaCo et invitation Paraphéo"
 
-#: ../browser/table.py:54
+#: ../browser/table.py:56
 #: ../browser/templates/macros.pt:11
 msgid "State"
 msgstr "État"
@@ -346,15 +346,15 @@ msgstr "État"
 msgid "Status"
 msgstr "Statut"
 
-#: ../browser/views.py:345
+#: ../browser/views.py:356
 msgid "The corresponding file content cannot be retrieved (${uid}) !"
 msgstr "Le contenu du fichier correspondant ne peut pas être récupéré (${uid}) !"
 
-#: ../browser/views.py:325
+#: ../browser/views.py:336
 msgid "The corresponding file identifier cannot be retrieved (${uid}) !"
 msgstr "L'identifiant du fichier n'a pas été trouvé (${uid}) !"
 
-#: ../browser/views.py:337
+#: ../browser/views.py:348
 msgid "The download period for this file has expired (was ${valid_date}) !"
 msgstr "La période de téléchargement de ce fichier a expiré le ${valid_date} !"
 
@@ -394,7 +394,7 @@ msgstr "La session est en préparation pour être envoyée dans Paraphéo par un
 msgid "The session is ready to be signed in Paraphéo."
 msgstr "La session est prête pour signature dans Paraphéo."
 
-#: ../browser/views.py:321
+#: ../browser/views.py:332
 msgid "This file identifier is not correct !"
 msgstr "Le format de cet identifiant de fichier n'est pas correct !"
 
@@ -410,7 +410,7 @@ msgstr "Ceci va supprimer l'élement courant de la session de signature"
 msgid "This will remove this element or configured sub elements from the relevant esign session"
 msgstr "Cela retirera cet élément ou les sous-éléments configurés de la session de signature"
 
-#: ../browser/table.py:71
+#: ../browser/table.py:73
 #: ../browser/templates/macros.pt:35
 msgid "Title"
 msgstr "Titre"
@@ -427,7 +427,7 @@ msgstr "Uninstalls the imio.esign add-on."
 msgid "Used in signers email template."
 msgstr "Utilisée dans le template d'email pour les signataires."
 
-#: ../browser/views.py:604
+#: ../browser/views.py:615
 msgid "User ${userid} has no email address configured. Skipping."
 msgstr "L'utilisateur ${userid} n'a pas d'adresse e-mail configurée. Ignoré."
 
@@ -459,7 +459,7 @@ msgstr "Le numéro de TVA doit commencer par 'BE'"
 msgid "VAT number used for esign billing (BE0123456789)."
 msgstr "Numéro de TVA utilisé pour la facturation esign (BE0123456789)."
 
-#: ../browser/table.py:262
+#: ../browser/table.py:276
 msgid "View session in dashboard"
 msgstr "Voir la session dans un tableau de bord"
 
@@ -475,7 +475,7 @@ msgstr "Oui"
 msgid "You are about to send emails to"
 msgstr "Vous êtes sur le point d'envoyer des emails à"
 
-#: ../browser/views.py:619
+#: ../browser/views.py:630
 msgid "You have been invited to Paraphéo"
 msgstr "Vous êtes invité à activer votre compte sur Paraphéo"
 
@@ -522,6 +522,10 @@ msgstr "Signée"
 #: ../browser/table.py
 msgid "status_title_not_signed"
 msgstr "Ce signataire n'a pas encore signé la session"
+
+#: ../browser/table.py
+msgid "status_title_refused"
+msgstr "Ce signataire a refusé la session"
 
 #: ../browser/table.py
 msgid "status_title_signed"

--- a/src/imio/esign/locales/imio.esign.pot
+++ b/src/imio/esign/locales/imio.esign.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-12 09:13+0000\n"
+"POT-Creation-Date: 2026-06-16 08:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,11 +15,11 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ../browser/views.py:317
+#: ../browser/views.py:328
 msgid "A file identifier must be passed in the url !"
 msgstr ""
 
-#: ../browser/table.py:212
+#: ../browser/table.py:226
 msgid "Actions"
 msgstr ""
 
@@ -39,11 +39,11 @@ msgstr ""
 msgid "Confirm Email Sending"
 msgstr ""
 
-#: ../browser/table.py:245
+#: ../browser/table.py:259
 msgid "Create external session"
 msgstr ""
 
-#: ../browser/table.py:231
+#: ../browser/table.py:245
 msgid "Delete session"
 msgstr ""
 
@@ -60,7 +60,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: ../browser/views.py:586
+#: ../browser/views.py:597
 msgid "Email content is not configured in the settings."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "Email:"
 msgstr ""
 
-#: ../browser/views.py:646
+#: ../browser/views.py:657
 msgid "Emails sent successfully to ${count} users."
 msgstr ""
 
@@ -88,11 +88,11 @@ msgstr ""
 msgid "Enabled?"
 msgstr ""
 
-#: ../browser/views.py:194
+#: ../browser/views.py:205
 msgid "Error while sending session: ${error}"
 msgstr ""
 
-#: ../browser/views.py:189
+#: ../browser/views.py:200
 msgid "External session sent successfully!"
 msgstr ""
 
@@ -100,11 +100,11 @@ msgstr ""
 msgid "External watchers emails"
 msgstr ""
 
-#: ../browser/views.py:633
+#: ../browser/views.py:644
 msgid "Failed to send email to ${userid}."
 msgstr ""
 
-#: ../browser/views.py:653
+#: ../browser/views.py:664
 msgid "Failed to send emails to ${count} users."
 msgstr ""
 
@@ -112,7 +112,7 @@ msgstr ""
 msgid "File URL download domain"
 msgstr ""
 
-#: ../browser/table.py:127
+#: ../browser/table.py:141
 msgid "Files"
 msgstr ""
 
@@ -153,7 +153,7 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: ../browser/table.py:196
+#: ../browser/table.py:210
 #: ../browser/templates/macros.pt:21
 msgid "Last update"
 msgstr ""
@@ -190,27 +190,27 @@ msgstr ""
 msgid "No files"
 msgstr ""
 
-#: ../browser/views.py:183
+#: ../browser/views.py:194
 msgid "No files found to be sent ! Session ${id} not sent."
 msgstr ""
 
-#: ../browser/views.py:169
+#: ../browser/views.py:180
 msgid "No seal code defined in configuration ! Session ${id} not sent."
 msgstr ""
 
-#: ../browser/views.py:176
+#: ../browser/views.py:187
 msgid "No seal email defined in configuration ! Session ${id} not sent."
 msgstr ""
 
-#: ../browser/views.py:128
+#: ../browser/views.py:139
 msgid "No session ID provided!"
 msgstr ""
 
-#: ../browser/views.py:541
+#: ../browser/views.py:552
 msgid "No users selected for CSV download."
 msgstr ""
 
-#: ../browser/views.py:580
+#: ../browser/views.py:591
 msgid "No users selected for email sending."
 msgstr ""
 
@@ -222,7 +222,7 @@ msgstr ""
 msgid "Parapheo url"
 msgstr ""
 
-#: ../browser/views.py:595
+#: ../browser/views.py:606
 msgid "Portal from email is not configured."
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Problem getting signers: \"${error}\")!"
 msgstr ""
 
-#: ../browser/table.py:156
+#: ../browser/table.py:170
 msgid "Quick look (${count} element(s), total size: ${size}) <span title='${help_title}' class='far fa-question-circle' />"
 msgstr ""
 
@@ -258,7 +258,7 @@ msgstr ""
 msgid "Seal email"
 msgstr ""
 
-#: ../browser/table.py:85
+#: ../browser/table.py:87
 #: ../browser/templates/macros.pt:28
 msgid "Sealed"
 msgstr ""
@@ -287,11 +287,11 @@ msgstr ""
 msgid "Session ID"
 msgstr ""
 
-#: ../browser/table.py:145
+#: ../browser/table.py:159
 msgid "Session can contain max ${max_session_files} elements and have a max size of ${max_session_size} MB."
 msgstr ""
 
-#: ../browser/views.py:136
+#: ../browser/views.py:147
 msgid "Session deleted successfully!"
 msgstr ""
 
@@ -299,7 +299,7 @@ msgstr ""
 msgid "Session information (${icon_url} Parapheo)"
 msgstr ""
 
-#: ../browser/views.py:138
+#: ../browser/views.py:149
 msgid "Session not found!"
 msgstr ""
 
@@ -307,7 +307,7 @@ msgstr ""
 msgid "Session not yet sent."
 msgstr ""
 
-#: ../browser/views.py:162
+#: ../browser/views.py:173
 msgid "Session with ID ${id} doesn't exist anymore !"
 msgstr ""
 
@@ -323,11 +323,11 @@ msgstr ""
 msgid "Sign url not yet received."
 msgstr ""
 
-#: ../browser/views.py:369
+#: ../browser/views.py:380
 msgid "Signed file download"
 msgstr ""
 
-#: ../browser/table.py:100
+#: ../browser/table.py:102
 #: ../browser/templates/macros.pt:42
 msgid "Signers"
 msgstr ""
@@ -336,7 +336,7 @@ msgstr ""
 msgid "Signing Users: Export CSV"
 msgstr ""
 
-#: ../browser/table.py:54
+#: ../browser/table.py:56
 #: ../browser/templates/macros.pt:11
 msgid "State"
 msgstr ""
@@ -345,15 +345,15 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: ../browser/views.py:345
+#: ../browser/views.py:356
 msgid "The corresponding file content cannot be retrieved (${uid}) !"
 msgstr ""
 
-#: ../browser/views.py:325
+#: ../browser/views.py:336
 msgid "The corresponding file identifier cannot be retrieved (${uid}) !"
 msgstr ""
 
-#: ../browser/views.py:337
+#: ../browser/views.py:348
 msgid "The download period for this file has expired (was ${valid_date}) !"
 msgstr ""
 
@@ -393,7 +393,7 @@ msgstr ""
 msgid "The session is ready to be signed in Paraphéo."
 msgstr ""
 
-#: ../browser/views.py:321
+#: ../browser/views.py:332
 msgid "This file identifier is not correct !"
 msgstr ""
 
@@ -409,7 +409,7 @@ msgstr ""
 msgid "This will remove this element or configured sub elements from the relevant esign session"
 msgstr ""
 
-#: ../browser/table.py:71
+#: ../browser/table.py:73
 #: ../browser/templates/macros.pt:35
 msgid "Title"
 msgstr ""
@@ -426,7 +426,7 @@ msgstr ""
 msgid "Used in signers email template."
 msgstr ""
 
-#: ../browser/views.py:604
+#: ../browser/views.py:615
 msgid "User ${userid} has no email address configured. Skipping."
 msgstr ""
 
@@ -458,7 +458,7 @@ msgstr ""
 msgid "VAT number used for esign billing (BE0123456789)."
 msgstr ""
 
-#: ../browser/table.py:262
+#: ../browser/table.py:276
 msgid "View session in dashboard"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "You are about to send emails to"
 msgstr ""
 
-#: ../browser/views.py:619
+#: ../browser/views.py:630
 msgid "You have been invited to Paraphéo"
 msgstr ""
 
@@ -520,6 +520,10 @@ msgstr ""
 
 #: ../browser/table.py
 msgid "status_title_not_signed"
+msgstr ""
+
+#: ../browser/table.py
+msgid "status_title_refused"
 msgstr ""
 
 #: ../browser/table.py

--- a/src/imio/esign/locales/imio.esign.pot
+++ b/src/imio/esign/locales/imio.esign.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-28 09:56+0000\n"
+"POT-Creation-Date: 2026-06-12 09:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 msgid "A file identifier must be passed in the url !"
 msgstr ""
 
-#: ../browser/table.py:206
+#: ../browser/table.py:212
 msgid "Actions"
 msgstr ""
 
@@ -39,11 +39,11 @@ msgstr ""
 msgid "Confirm Email Sending"
 msgstr ""
 
-#: ../browser/table.py:239
+#: ../browser/table.py:245
 msgid "Create external session"
 msgstr ""
 
-#: ../browser/table.py:225
+#: ../browser/table.py:231
 msgid "Delete session"
 msgstr ""
 
@@ -112,7 +112,7 @@ msgstr ""
 msgid "File URL download domain"
 msgstr ""
 
-#: ../browser/table.py:121
+#: ../browser/table.py:127
 msgid "Files"
 msgstr ""
 
@@ -153,7 +153,7 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: ../browser/table.py:190
+#: ../browser/table.py:196
 #: ../browser/templates/macros.pt:21
 msgid "Last update"
 msgstr ""
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Problem getting signers: \"${error}\")!"
 msgstr ""
 
-#: ../browser/table.py:150
+#: ../browser/table.py:156
 msgid "Quick look (${count} element(s), total size: ${size}) <span title='${help_title}' class='far fa-question-circle' />"
 msgstr ""
 
@@ -279,7 +279,7 @@ msgstr ""
 msgid "Send Emails"
 msgstr ""
 
-#: ../utils.py:207
+#: ../utils.py:217
 msgid "Session ${id}"
 msgstr ""
 
@@ -287,7 +287,7 @@ msgstr ""
 msgid "Session ID"
 msgstr ""
 
-#: ../browser/table.py:139
+#: ../browser/table.py:145
 msgid "Session can contain max ${max_session_files} elements and have a max size of ${max_session_size} MB."
 msgstr ""
 
@@ -458,7 +458,7 @@ msgstr ""
 msgid "VAT number used for esign billing (BE0123456789)."
 msgstr ""
 
-#: ../browser/table.py:256
+#: ../browser/table.py:262
 msgid "View session in dashboard"
 msgstr ""
 
@@ -516,6 +516,14 @@ msgstr ""
 
 #: ../browser/table.py
 msgid "signed"
+msgstr ""
+
+#: ../browser/table.py
+msgid "status_title_not_signed"
+msgstr ""
+
+#: ../browser/table.py
+msgid "status_title_signed"
 msgstr ""
 
 #: ../browser/table.py

--- a/src/imio/esign/locales/manual.pot
+++ b/src/imio/esign/locales/manual.pot
@@ -98,3 +98,6 @@ msgstr ""
 msgid "status_title_not_signed"
 msgstr ""
 
+#: ../browser/table.py
+msgid "status_title_refused"
+msgstr ""

--- a/src/imio/esign/locales/manual.pot
+++ b/src/imio/esign/locales/manual.pot
@@ -90,3 +90,11 @@ msgstr ""
 msgid "to_sign"
 msgstr ""
 
+#: ../browser/table.py
+msgid "status_title_signed"
+msgstr ""
+
+#: ../browser/table.py
+msgid "status_title_not_signed"
+msgstr ""
+


### PR DESCRIPTION
In info viewlet, display `signed` in green.
See #PARAF-476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added red/green (and refusal) icon indicators next to signers to reflect signature status.
  * Updated the signer “Status” display to style results by status and show tooltip titles for signed, not signed, and refused.
  * Enhanced the info viewlet to highlight “signed” in green.

* **Localization**
  * Added new translatable strings for signer status tooltip/title text (English and French).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->